### PR TITLE
Make templates better

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:types": "tsc --emitDeclarationOnly ",
     "build-storybook": "build-storybook",
     "eslint": "eslint ${ESLINT_FORMAT_OPTIONS:-} --ignore --ignore-path .gitignore",
-    "lint": "npm-run-all lint:*",
+    "lint": "npm-run-all --continue-on-error --parallel lint:*",
     "lint:changelog": "commitlint --from origin/master --to HEAD",
     "lint:es": "npm run --silent eslint -- .",
     "prelint:types": "mkdirp reports/style",

--- a/src/description/conditional-description.tsx
+++ b/src/description/conditional-description.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
 
-import {Renderer} from '../support';
+import {Renderer} from '../renderers/types';
 
 import {Description} from './description';
 

--- a/src/description/description.tsx
+++ b/src/description/description.tsx
@@ -2,7 +2,7 @@ import React, {useContext, useMemo} from 'react';
 import cx from 'classnames';
 
 import {AnyRenderer} from '../renderers';
-import {Renderer as RendererType} from '../support';
+import {Renderer as RendererType} from '../renderers/types';
 
 import {DescriptionListContext, DescriptionList} from './description-list';
 

--- a/src/renderers/any-renderer/any-renderer.tsx
+++ b/src/renderers/any-renderer/any-renderer.tsx
@@ -5,7 +5,8 @@ import {BooleanRenderer, BooleanRendererContextType} from '../boolean-renderer';
 import {DateRenderer, DateRendererContextProps} from '../date-renderer';
 import {ObjectRenderer} from '../object-renderer';
 import {NullRenderer, NullRendererContextType} from '../null-renderer';
-import {RendererProps, useContextWithDefaults} from '../../support';
+import {useContextWithDefaults} from '../../support';
+import {RendererProps} from '../types';
 
 export type AnyRendererContextType = {
   readonly boolean?: BooleanRendererContextType;

--- a/src/renderers/boolean-renderer/boolean-renderer.tsx
+++ b/src/renderers/boolean-renderer/boolean-renderer.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 
-import {
-  RendererDefault,
-  RendererProps,
-  useContextWithDefaults,
-} from '../../support';
+import {useContextWithDefaults} from '../../support';
+import {RendererDefault, RendererProps} from '../types';
 
 export type BooleanRendererContextType = {
   readonly no: RendererDefault;

--- a/src/renderers/date-renderer/date-renderer.tsx
+++ b/src/renderers/date-renderer/date-renderer.tsx
@@ -4,8 +4,9 @@ import React from 'react';
 import Moment from 'react-moment';
 import moment from 'moment';
 
-import {RendererProps, useContextWithDefaults} from '../../support';
+import {useContextWithDefaults} from '../../support';
 import {NullRenderer} from '../null-renderer';
+import {RendererProps} from '../types';
 
 export type DateRendererContextProps = {
   readonly format?: string;

--- a/src/renderers/index.stories.mdx
+++ b/src/renderers/index.stories.mdx
@@ -19,7 +19,7 @@ table. Our CSV parser could recognize column headings, numbers, dates, and
 possibly even booleans, but if we don't know a field's type a priori, then we
 can't apply appropriate formatting.
 
-Renders are type-specific components that do close to the right thing when we
+Renderers are type-specific components that do close to the right thing when we
 can't know exactly what the data looks in advance.
 
 All renderers must accept a `value` prop. Renderers may accept additional
@@ -70,7 +70,7 @@ have no idea what data we might get? Enter the `AnyRenderer`
   </React.Fragment>
 </Canvas>
 
-Now, with the `AnyRenderer`, we put put any arbitrary data on a page and get
+Now, with the `AnyRenderer`, we can put any arbitrary data on a page and get
 something fairly reasonable. Most of its per-type renderers support
 customization, so if we have a partial understanding of our data, we can
 customize appropriately via the Context and programmatically drive our output.

--- a/src/renderers/index.tsx
+++ b/src/renderers/index.tsx
@@ -4,3 +4,4 @@ export * from './date-renderer';
 export * from './maybe-renderer';
 export * from './object-renderer';
 export * from './null-renderer';
+export * from './types';

--- a/src/renderers/null-renderer/null-renderer.tsx
+++ b/src/renderers/null-renderer/null-renderer.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 
-import {
-  RendererDefault,
-  RendererProps,
-  useContextWithDefaults,
-} from '../../support';
+import {useContextWithDefaults} from '../../support';
+import {RendererDefault, RendererProps} from '../types';
 
 export type NullRendererContextType = {
   readonly null: RendererDefault;

--- a/src/renderers/object-renderer/object-renderer.tsx
+++ b/src/renderers/object-renderer/object-renderer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {Code} from '../..';
-import {RendererProps} from '../../support';
+import {RendererProps} from '../types';
 
 export type ObjectRendererProps = RendererProps<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/src/renderers/types.tsx
+++ b/src/renderers/types.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+/**
+ * Placeholder. Ideally, this would be Renderer, but the generics are
+ * troublesome and I haven't had time to work it out yet.
+ */
+export type RendererDefault = React.ReactNode;
+
+export type RendererProps<
+  T extends unknown = unknown,
+  C = unknown
+> = Partial<C> & {
+  value: T;
+};
+
+export type Renderer<T = unknown, C = unknown> = React.ComponentType<
+  RendererProps<T, C>
+>;

--- a/src/support.tsx
+++ b/src/support.tsx
@@ -21,24 +21,6 @@ export function useContextWithDefaults<T>(
 }
 
 /**
- * Placeholder. Eventually, this will also include React.ComponentType so that
- * we can make dynamic defaults (for example, perhaps we'd want to truncate
- * strings over a certain length).
- */
-export type RendererDefault = React.ReactNode;
-
-export type RendererProps<
-  T extends unknown = unknown,
-  C = unknown
-> = Partial<C> & {
-  value: T;
-};
-
-export type Renderer<T = unknown, C = unknown> = React.ComponentType<
-  RendererProps<T, C>
->;
-
-/**
  * helper type for all known valid JSX element constructors (class and function
  * based)
  *

--- a/src/template-specializations/array-table/__snapshots__/array-table.stories.storyshot
+++ b/src/template-specializations/array-table/__snapshots__/array-table.stories.storyshot
@@ -406,25 +406,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Joshua
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jenkins
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-04-21T09:24:38.262Z"}
@@ -439,25 +435,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lennie
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Krajcik
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         69
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-21T20:24:48.713Z"}
@@ -472,25 +464,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Ophelia
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Olson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         92
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-05T01:04:28.401Z"}
@@ -505,25 +493,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Annabelle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Hamill
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         31
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-10-04T14:50:38.937Z"}
@@ -538,25 +522,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Foster
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Runolfsson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         83
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-30T22:08:33.801Z"}
@@ -571,25 +551,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dayton
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Orn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         90
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-08T08:53:03.410Z"}
@@ -604,25 +580,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Joshua
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Crooks
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         3
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-03-03T07:23:58.735Z"}
@@ -637,25 +609,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jermaine
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bayer
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         10
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-26T10:22:53.934Z"}
@@ -670,25 +638,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Corrine
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Miller
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-26T10:55:45.296Z"}
@@ -703,25 +667,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brice
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schuster
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         70
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-07-02T11:06:23.011Z"}
@@ -736,25 +696,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Chelsey
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kub
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         34
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-18T19:07:03.671Z"}
@@ -769,25 +725,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Mohammad
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Walter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         81
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-25T13:46:21.818Z"}
@@ -802,25 +754,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Polly
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Hagenes
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         32
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-06T20:55:24.609Z"}
@@ -835,25 +783,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Felipe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Quitzon
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         99
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-19T17:47:19.622Z"}
@@ -868,25 +812,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Malinda
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Anderson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         18
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-24T22:06:01.401Z"}
@@ -901,25 +841,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Layla
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Luettgen
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         7
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-13T09:50:12.368Z"}
@@ -934,25 +870,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dewitt
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brekke
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         11
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-11-02T20:46:49.847Z"}
@@ -967,25 +899,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Anna
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kunze
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-01-21T05:32:43.557Z"}
@@ -1000,25 +928,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Morton
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lowe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         86
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-10-18T01:05:35.725Z"}
@@ -1033,25 +957,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Marlin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Turner
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-01-03T19:14:42.456Z"}
@@ -1066,25 +986,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Gerry
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kihn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         50
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-11T23:26:48.223Z"}
@@ -1099,25 +1015,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schuyler
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Thiel
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-13T23:49:34.437Z"}
@@ -1132,25 +1044,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zola
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Cassin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         62
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-12T01:31:04.904Z"}
@@ -1165,25 +1073,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Elaina
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Effertz
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-01T03:50:19.589Z"}
@@ -1198,25 +1102,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dorothea
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Langosh
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         41
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-25T13:06:11.376Z"}
@@ -1231,25 +1131,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Walter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Collins
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         49
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-11T09:50:45.150Z"}
@@ -1264,25 +1160,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lexi
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         White
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         57
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-01-19T11:25:25.523Z"}
@@ -1297,25 +1189,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Barrett
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Stehr
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         18
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-09T21:37:57.360Z"}
@@ -1330,25 +1218,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Clay
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Muller
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         94
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-04-22T09:59:45.171Z"}
@@ -1363,25 +1247,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Omer
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Wolf
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-05T17:02:28.842Z"}
@@ -1396,25 +1276,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bradly
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Williamson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         6
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-03-21T19:15:40.723Z"}
@@ -1429,25 +1305,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Merle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Stark
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         14
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-01-04T01:31:58.194Z"}
@@ -1462,25 +1334,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zelda
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dach
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         5
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-19T04:24:09.772Z"}
@@ -1495,25 +1363,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Turner
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Prohaska
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         28
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-29T01:58:05.913Z"}
@@ -1528,25 +1392,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Savanah
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Grant
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-03T15:09:10.943Z"}
@@ -1561,25 +1421,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Fred
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Koss
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-06-12T03:59:20.701Z"}
@@ -1594,25 +1450,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kelton
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Trantow
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         97
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-24T03:47:22.753Z"}
@@ -1627,25 +1479,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Cicero
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Nienow
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         83
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-27T02:09:38.799Z"}
@@ -1660,25 +1508,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Emie
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Doyle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         3
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-21T01:41:25.229Z"}
@@ -1693,25 +1537,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Garland
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         O'Keefe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         58
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-12T03:04:37.216Z"}
@@ -1726,25 +1566,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kaela
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Runte
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-02-26T13:40:28.643Z"}
@@ -1759,25 +1595,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Josianne
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Carter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         92
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-13T23:32:56.271Z"}
@@ -1792,25 +1624,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Myrtis
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Macejkovic
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         1
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-23T13:30:19.412Z"}
@@ -1825,25 +1653,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Theresa
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kirlin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         43
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-23T04:05:52.696Z"}
@@ -1858,25 +1682,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Molly
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schaden
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-04-12T07:23:10.017Z"}
@@ -1891,25 +1711,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Florence
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bechtelar
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         19
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-16T14:02:35.829Z"}
@@ -1924,25 +1740,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Wiley
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brown
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         91
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-08-29T01:42:14.303Z"}
@@ -1957,25 +1769,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Moshe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Flatley
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         96
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-14T04:52:56.689Z"}
@@ -1990,25 +1798,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zaria
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Senger
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         22
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-11-07T02:17:13.386Z"}
@@ -2023,25 +1827,21 @@ exports[`Storyshots Template Specialization/ArrayTable Array Table 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Eloise
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Beier
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         84
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-19T09:25:33.489Z"}
@@ -2469,25 +2269,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Joshua
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jenkins
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-04-21T09:24:38.262Z"}
@@ -2498,7 +2294,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         53620521738
       </td>
@@ -2508,25 +2303,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lennie
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Krajcik
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         69
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-21T20:24:48.713Z"}
@@ -2537,7 +2328,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         19366511287
       </td>
@@ -2547,25 +2337,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Ophelia
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Olson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         92
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-05T01:04:28.401Z"}
@@ -2576,7 +2362,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         57711331599
       </td>
@@ -2586,25 +2371,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Annabelle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Hamill
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         31
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-10-04T14:50:38.937Z"}
@@ -2615,7 +2396,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         7636161063
       </td>
@@ -2625,25 +2405,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Foster
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Runolfsson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         83
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-30T22:08:33.801Z"}
@@ -2654,7 +2430,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         7955486199
       </td>
@@ -2664,25 +2439,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dayton
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Orn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         90
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-08T08:53:03.410Z"}
@@ -2693,7 +2464,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9904016590
       </td>
@@ -2703,25 +2473,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Joshua
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Crooks
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         3
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-03-03T07:23:58.735Z"}
@@ -2732,7 +2498,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         26238961265
       </td>
@@ -2742,25 +2507,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jermaine
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bayer
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         10
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-26T10:22:53.934Z"}
@@ -2771,7 +2532,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         55863426066
       </td>
@@ -2781,25 +2541,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Corrine
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Miller
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-26T10:55:45.296Z"}
@@ -2810,7 +2566,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         39963854704
       </td>
@@ -2820,25 +2575,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brice
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schuster
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         70
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-07-02T11:06:23.011Z"}
@@ -2849,7 +2600,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         47393616989
       </td>
@@ -2859,25 +2609,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Chelsey
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kub
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         34
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-18T19:07:03.671Z"}
@@ -2888,7 +2634,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         38033576329
       </td>
@@ -2898,25 +2643,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Mohammad
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Walter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         81
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-25T13:46:21.818Z"}
@@ -2927,7 +2668,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         19044818182
       </td>
@@ -2937,25 +2677,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Polly
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Hagenes
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         32
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-06T20:55:24.609Z"}
@@ -2966,7 +2702,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         39063875391
       </td>
@@ -2976,25 +2711,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Felipe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Quitzon
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         99
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-19T17:47:19.622Z"}
@@ -3005,7 +2736,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         56441560378
       </td>
@@ -3015,25 +2745,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Malinda
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Anderson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         18
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-24T22:06:01.401Z"}
@@ -3044,7 +2770,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         40096438599
       </td>
@@ -3054,25 +2779,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Layla
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Luettgen
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         7
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-13T09:50:12.368Z"}
@@ -3083,7 +2804,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         33228587632
       </td>
@@ -3093,25 +2813,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dewitt
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brekke
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         11
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-11-02T20:46:49.847Z"}
@@ -3122,7 +2838,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         5109190153
       </td>
@@ -3132,25 +2847,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Anna
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kunze
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-01-21T05:32:43.557Z"}
@@ -3161,7 +2872,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         61410436443
       </td>
@@ -3171,25 +2881,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Morton
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lowe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         86
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-10-18T01:05:35.725Z"}
@@ -3200,7 +2906,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         6476064275
       </td>
@@ -3210,25 +2915,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Marlin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Turner
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-01-03T19:14:42.456Z"}
@@ -3239,7 +2940,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         -242082456
       </td>
@@ -3249,25 +2949,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Gerry
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kihn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         50
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-11T23:26:48.223Z"}
@@ -3278,7 +2974,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         1729991777
       </td>
@@ -3288,25 +2983,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schuyler
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Thiel
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-13T23:49:34.437Z"}
@@ -3317,7 +3008,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         20045425563
       </td>
@@ -3327,25 +3017,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zola
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Cassin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         62
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-12T01:31:04.904Z"}
@@ -3356,7 +3042,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9584935096
       </td>
@@ -3366,25 +3051,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Elaina
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Effertz
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-01T03:50:19.589Z"}
@@ -3395,7 +3076,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         34286980411
       </td>
@@ -3405,25 +3085,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dorothea
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Langosh
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         41
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-25T13:06:11.376Z"}
@@ -3434,7 +3110,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         32180028624
       </td>
@@ -3444,25 +3119,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Walter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Collins
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         49
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-11T09:50:45.150Z"}
@@ -3473,7 +3144,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35993354850
       </td>
@@ -3483,25 +3153,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lexi
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         White
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         57
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-01-19T11:25:25.523Z"}
@@ -3512,7 +3178,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         30026074477
       </td>
@@ -3522,25 +3187,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Barrett
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Stehr
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         18
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-09T21:37:57.360Z"}
@@ -3551,7 +3212,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         33531722640
       </td>
@@ -3561,25 +3221,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Clay
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Muller
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         94
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-04-22T09:59:45.171Z"}
@@ -3590,7 +3246,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         21909614829
       </td>
@@ -3600,25 +3255,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Omer
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Wolf
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-05T17:02:28.842Z"}
@@ -3629,7 +3280,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         41756251158
       </td>
@@ -3639,25 +3289,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bradly
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Williamson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         6
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-03-21T19:15:40.723Z"}
@@ -3668,7 +3314,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         24641059277
       </td>
@@ -3678,25 +3323,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Merle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Stark
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         14
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-01-04T01:31:58.194Z"}
@@ -3707,7 +3348,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         -264718194
       </td>
@@ -3717,25 +3357,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zelda
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dach
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         5
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-19T04:24:09.772Z"}
@@ -3746,7 +3382,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         14326550228
       </td>
@@ -3756,25 +3391,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Turner
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Prohaska
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         28
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-29T01:58:05.913Z"}
@@ -3785,7 +3416,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         252114087
       </td>
@@ -3795,25 +3425,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Savanah
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Grant
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-03T15:09:10.943Z"}
@@ -3824,7 +3450,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         20940649057
       </td>
@@ -3834,25 +3459,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Fred
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Koss
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-06-12T03:59:20.701Z"}
@@ -3863,7 +3484,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         17524839299
       </td>
@@ -3873,25 +3493,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kelton
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Trantow
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         97
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-24T03:47:22.753Z"}
@@ -3902,7 +3518,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         13896757247
       </td>
@@ -3912,25 +3527,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Cicero
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Nienow
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         83
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-27T02:09:38.799Z"}
@@ -3941,7 +3552,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         32046621201
       </td>
@@ -3951,25 +3561,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Emie
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Doyle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         3
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-21T01:41:25.229Z"}
@@ -3980,7 +3586,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         14163514771
       </td>
@@ -3990,25 +3595,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Garland
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         O'Keefe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         58
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-12T03:04:37.216Z"}
@@ -4019,7 +3620,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35931322784
       </td>
@@ -4029,25 +3629,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kaela
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Runte
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-02-26T13:40:28.643Z"}
@@ -4058,7 +3654,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         -4887628643
       </td>
@@ -4068,25 +3663,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Josianne
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Carter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         92
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-13T23:32:56.271Z"}
@@ -4097,7 +3688,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9419223729
       </td>
@@ -4107,25 +3697,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Myrtis
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Macejkovic
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         1
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-23T13:30:19.412Z"}
@@ -4136,7 +3722,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         34943380588
       </td>
@@ -4146,25 +3731,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Theresa
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kirlin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         43
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-23T04:05:52.696Z"}
@@ -4175,7 +3756,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         13982047304
       </td>
@@ -4185,25 +3765,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Molly
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schaden
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-04-12T07:23:10.017Z"}
@@ -4214,7 +3790,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         22783009983
       </td>
@@ -4224,25 +3799,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Florence
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bechtelar
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         19
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-16T14:02:35.829Z"}
@@ -4253,7 +3824,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         1331844171
       </td>
@@ -4263,25 +3833,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Wiley
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brown
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         91
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-08-29T01:42:14.303Z"}
@@ -4292,7 +3858,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         10793865697
       </td>
@@ -4302,25 +3867,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Moshe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Flatley
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         96
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-14T04:52:56.689Z"}
@@ -4331,7 +3892,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         38430423311
       </td>
@@ -4341,25 +3901,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zaria
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Senger
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         22
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-11-07T02:17:13.386Z"}
@@ -4370,7 +3926,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         4743766614
       </td>
@@ -4380,25 +3935,21 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Eloise
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Beier
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         84
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-19T09:25:33.489Z"}
@@ -4409,7 +3960,6 @@ exports[`Storyshots Template Specialization/ArrayTable Duplicate Fields 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         37982066511
       </td>
@@ -4924,19 +4474,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Milan
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jenkins
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-04-21T09:24:38.262Z"}
@@ -4947,7 +4494,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9
       </td>
@@ -4957,19 +4503,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Melyna
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Krajcik
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-21T20:24:48.713Z"}
@@ -4980,7 +4523,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         69
       </td>
@@ -4990,19 +4532,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Daisha
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Olson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-05T01:04:28.401Z"}
@@ -5013,7 +4552,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         92
       </td>
@@ -5023,19 +4561,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Coty
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Hamill
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-10-04T14:50:38.937Z"}
@@ -5046,7 +4581,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         31
       </td>
@@ -5056,19 +4590,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kenna
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Runolfsson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-30T22:08:33.801Z"}
@@ -5079,7 +4610,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         83
       </td>
@@ -5089,19 +4619,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Shanny
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Orn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-08T08:53:03.410Z"}
@@ -5112,7 +4639,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         90
       </td>
@@ -5122,19 +4648,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jerome
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Crooks
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-03-03T07:23:58.735Z"}
@@ -5145,7 +4668,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         3
       </td>
@@ -5155,19 +4677,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Leonora
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bayer
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-26T10:22:53.934Z"}
@@ -5178,7 +4697,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         10
       </td>
@@ -5188,19 +4706,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zakary
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Miller
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-26T10:55:45.296Z"}
@@ -5211,7 +4726,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
@@ -5221,19 +4735,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Ken
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schuster
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-07-02T11:06:23.011Z"}
@@ -5244,7 +4755,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         70
       </td>
@@ -5254,19 +4764,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Haylee
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kub
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-18T19:07:03.671Z"}
@@ -5277,7 +4784,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         34
       </td>
@@ -5287,19 +4793,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Curtis
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Walter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-25T13:46:21.818Z"}
@@ -5310,7 +4813,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         81
       </td>
@@ -5320,19 +4822,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Melisa
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Hagenes
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-06T20:55:24.609Z"}
@@ -5343,7 +4842,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         32
       </td>
@@ -5353,19 +4851,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Isabel
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Quitzon
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-19T17:47:19.622Z"}
@@ -5376,7 +4871,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         99
       </td>
@@ -5386,19 +4880,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Wilburn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Anderson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-24T22:06:01.401Z"}
@@ -5409,7 +4900,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         18
       </td>
@@ -5419,19 +4909,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Terrance
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Luettgen
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-13T09:50:12.368Z"}
@@ -5442,7 +4929,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         7
       </td>
@@ -5452,19 +4938,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Miles
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brekke
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-11-02T20:46:49.847Z"}
@@ -5475,7 +4958,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         11
       </td>
@@ -5485,19 +4967,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Skye
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kunze
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-01-21T05:32:43.557Z"}
@@ -5508,7 +4987,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
@@ -5518,19 +4996,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Claudine
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lowe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-10-18T01:05:35.725Z"}
@@ -5541,7 +5016,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         86
       </td>
@@ -5551,19 +5025,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Landen
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Turner
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-01-03T19:14:42.456Z"}
@@ -5574,7 +5045,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
@@ -5584,19 +5054,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Antonia
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kihn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-11T23:26:48.223Z"}
@@ -5607,7 +5074,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         50
       </td>
@@ -5617,19 +5083,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dewitt
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Thiel
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-13T23:49:34.437Z"}
@@ -5640,7 +5103,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9
       </td>
@@ -5650,19 +5112,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Horacio
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Cassin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-12T01:31:04.904Z"}
@@ -5673,7 +5132,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         62
       </td>
@@ -5683,19 +5141,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kathleen
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Effertz
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-01T03:50:19.589Z"}
@@ -5706,7 +5161,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
@@ -5716,19 +5170,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Ella
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Langosh
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-25T13:06:11.376Z"}
@@ -5739,7 +5190,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         41
       </td>
@@ -5749,19 +5199,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jacklyn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Collins
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-11T09:50:45.150Z"}
@@ -5772,7 +5219,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         49
       </td>
@@ -5782,19 +5228,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Loraine
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         White
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-01-19T11:25:25.523Z"}
@@ -5805,7 +5248,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         57
       </td>
@@ -5815,19 +5257,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Christa
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Stehr
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-09T21:37:57.360Z"}
@@ -5838,7 +5277,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         18
       </td>
@@ -5848,19 +5286,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Giovanni
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Muller
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-04-22T09:59:45.171Z"}
@@ -5871,7 +5306,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         94
       </td>
@@ -5881,19 +5315,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Rick
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Wolf
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-05T17:02:28.842Z"}
@@ -5904,7 +5335,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
@@ -5914,19 +5344,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         George
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Williamson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-03-21T19:15:40.723Z"}
@@ -5937,7 +5364,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         6
       </td>
@@ -5947,19 +5373,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jessie
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Stark
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-01-04T01:31:58.194Z"}
@@ -5970,7 +5393,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         14
       </td>
@@ -5980,19 +5402,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Shaylee
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dach
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-19T04:24:09.772Z"}
@@ -6003,7 +5422,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         5
       </td>
@@ -6013,19 +5431,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Carmelo
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Prohaska
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-29T01:58:05.913Z"}
@@ -6036,7 +5451,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         28
       </td>
@@ -6046,19 +5460,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Rebeka
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Grant
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-03T15:09:10.943Z"}
@@ -6069,7 +5480,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
@@ -6079,19 +5489,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kraig
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Koss
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-06-12T03:59:20.701Z"}
@@ -6102,7 +5509,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
@@ -6112,19 +5518,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brock
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Trantow
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-24T03:47:22.753Z"}
@@ -6135,7 +5538,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         97
       </td>
@@ -6145,19 +5547,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Marley
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Nienow
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-27T02:09:38.799Z"}
@@ -6168,7 +5567,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         83
       </td>
@@ -6178,19 +5576,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kyra
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Doyle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-21T01:41:25.229Z"}
@@ -6201,7 +5596,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         3
       </td>
@@ -6211,19 +5605,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Marcel
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         O'Keefe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-12T03:04:37.216Z"}
@@ -6234,7 +5625,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         58
       </td>
@@ -6244,19 +5634,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bianka
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Runte
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-02-26T13:40:28.643Z"}
@@ -6267,7 +5654,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
@@ -6277,19 +5663,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Fredy
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Carter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-13T23:32:56.271Z"}
@@ -6300,7 +5683,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         92
       </td>
@@ -6310,19 +5692,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zelda
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Macejkovic
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-23T13:30:19.412Z"}
@@ -6333,7 +5712,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         1
       </td>
@@ -6343,19 +5721,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Giovani
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kirlin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-23T04:05:52.696Z"}
@@ -6366,7 +5741,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         43
       </td>
@@ -6376,19 +5750,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Griffin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schaden
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-04-12T07:23:10.017Z"}
@@ -6399,7 +5770,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
@@ -6409,19 +5779,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Nathaniel
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bechtelar
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-16T14:02:35.829Z"}
@@ -6432,7 +5799,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         19
       </td>
@@ -6442,19 +5808,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Amiya
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brown
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-08-29T01:42:14.303Z"}
@@ -6465,7 +5828,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         91
       </td>
@@ -6475,19 +5837,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Vivian
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Flatley
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-14T04:52:56.689Z"}
@@ -6498,7 +5857,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         96
       </td>
@@ -6508,19 +5866,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lysanne
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Senger
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-11-07T02:17:13.386Z"}
@@ -6531,7 +5886,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         22
       </td>
@@ -6541,19 +5895,16 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Ena
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Beier
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-19T09:25:33.489Z"}
@@ -6564,7 +5915,6 @@ exports[`Storyshots Template Specialization/ArrayTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         84
       </td>
@@ -6979,19 +6329,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jenkins
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Joshua
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-04-21T09:24:38.262Z"}
@@ -7002,7 +6349,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9
       </td>
@@ -7012,19 +6358,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Krajcik
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lennie
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-21T20:24:48.713Z"}
@@ -7035,7 +6378,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         69
       </td>
@@ -7045,19 +6387,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Olson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Ophelia
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-05T01:04:28.401Z"}
@@ -7068,7 +6407,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         92
       </td>
@@ -7078,19 +6416,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Hamill
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Annabelle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-10-04T14:50:38.937Z"}
@@ -7101,7 +6436,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         31
       </td>
@@ -7111,19 +6445,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Runolfsson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Foster
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-30T22:08:33.801Z"}
@@ -7134,7 +6465,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         83
       </td>
@@ -7144,19 +6474,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Orn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dayton
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-08T08:53:03.410Z"}
@@ -7167,7 +6494,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         90
       </td>
@@ -7177,19 +6503,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Crooks
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Joshua
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-03-03T07:23:58.735Z"}
@@ -7200,7 +6523,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         3
       </td>
@@ -7210,19 +6532,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bayer
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jermaine
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-26T10:22:53.934Z"}
@@ -7233,7 +6552,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         10
       </td>
@@ -7243,19 +6561,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Miller
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Corrine
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-26T10:55:45.296Z"}
@@ -7266,7 +6581,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
@@ -7276,19 +6590,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schuster
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brice
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-07-02T11:06:23.011Z"}
@@ -7299,7 +6610,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         70
       </td>
@@ -7309,19 +6619,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kub
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Chelsey
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-18T19:07:03.671Z"}
@@ -7332,7 +6639,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         34
       </td>
@@ -7342,19 +6648,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Walter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Mohammad
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-25T13:46:21.818Z"}
@@ -7365,7 +6668,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         81
       </td>
@@ -7375,19 +6677,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Hagenes
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Polly
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-06T20:55:24.609Z"}
@@ -7398,7 +6697,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         32
       </td>
@@ -7408,19 +6706,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Quitzon
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Felipe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-19T17:47:19.622Z"}
@@ -7431,7 +6726,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         99
       </td>
@@ -7441,19 +6735,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Anderson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Malinda
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-24T22:06:01.401Z"}
@@ -7464,7 +6755,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         18
       </td>
@@ -7474,19 +6764,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Luettgen
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Layla
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-13T09:50:12.368Z"}
@@ -7497,7 +6784,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         7
       </td>
@@ -7507,19 +6793,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brekke
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dewitt
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-11-02T20:46:49.847Z"}
@@ -7530,7 +6813,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         11
       </td>
@@ -7540,19 +6822,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kunze
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Anna
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-01-21T05:32:43.557Z"}
@@ -7563,7 +6842,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
@@ -7573,19 +6851,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lowe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Morton
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-10-18T01:05:35.725Z"}
@@ -7596,7 +6871,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         86
       </td>
@@ -7606,19 +6880,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Turner
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Marlin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-01-03T19:14:42.456Z"}
@@ -7629,7 +6900,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
@@ -7639,19 +6909,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kihn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Gerry
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-11T23:26:48.223Z"}
@@ -7662,7 +6929,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         50
       </td>
@@ -7672,19 +6938,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Thiel
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schuyler
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-13T23:49:34.437Z"}
@@ -7695,7 +6958,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9
       </td>
@@ -7705,19 +6967,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Cassin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zola
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-12T01:31:04.904Z"}
@@ -7728,7 +6987,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         62
       </td>
@@ -7738,19 +6996,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Effertz
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Elaina
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-01T03:50:19.589Z"}
@@ -7761,7 +7016,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
@@ -7771,19 +7025,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Langosh
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dorothea
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-25T13:06:11.376Z"}
@@ -7794,7 +7045,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         41
       </td>
@@ -7804,19 +7054,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Collins
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Walter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-11T09:50:45.150Z"}
@@ -7827,7 +7074,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         49
       </td>
@@ -7837,19 +7083,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         White
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lexi
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-01-19T11:25:25.523Z"}
@@ -7860,7 +7103,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         57
       </td>
@@ -7870,19 +7112,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Stehr
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Barrett
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-09T21:37:57.360Z"}
@@ -7893,7 +7132,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         18
       </td>
@@ -7903,19 +7141,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Muller
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Clay
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-04-22T09:59:45.171Z"}
@@ -7926,7 +7161,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         94
       </td>
@@ -7936,19 +7170,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Wolf
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Omer
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-05T17:02:28.842Z"}
@@ -7959,7 +7190,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
@@ -7969,19 +7199,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Williamson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bradly
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-03-21T19:15:40.723Z"}
@@ -7992,7 +7219,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         6
       </td>
@@ -8002,19 +7228,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Stark
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Merle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-01-04T01:31:58.194Z"}
@@ -8025,7 +7248,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         14
       </td>
@@ -8035,19 +7257,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dach
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zelda
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-19T04:24:09.772Z"}
@@ -8058,7 +7277,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         5
       </td>
@@ -8068,19 +7286,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Prohaska
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Turner
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-29T01:58:05.913Z"}
@@ -8091,7 +7306,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         28
       </td>
@@ -8101,19 +7315,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Grant
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Savanah
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-03T15:09:10.943Z"}
@@ -8124,7 +7335,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
@@ -8134,19 +7344,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Koss
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Fred
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-06-12T03:59:20.701Z"}
@@ -8157,7 +7364,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
@@ -8167,19 +7373,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Trantow
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kelton
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-24T03:47:22.753Z"}
@@ -8190,7 +7393,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         97
       </td>
@@ -8200,19 +7402,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Nienow
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Cicero
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-27T02:09:38.799Z"}
@@ -8223,7 +7422,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         83
       </td>
@@ -8233,19 +7431,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Doyle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Emie
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-21T01:41:25.229Z"}
@@ -8256,7 +7451,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         3
       </td>
@@ -8266,19 +7460,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         O'Keefe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Garland
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-12T03:04:37.216Z"}
@@ -8289,7 +7480,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         58
       </td>
@@ -8299,19 +7489,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Runte
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kaela
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-02-26T13:40:28.643Z"}
@@ -8322,7 +7509,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
@@ -8332,19 +7518,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Carter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Josianne
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-13T23:32:56.271Z"}
@@ -8355,7 +7538,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         92
       </td>
@@ -8365,19 +7547,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Macejkovic
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Myrtis
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-23T13:30:19.412Z"}
@@ -8388,7 +7567,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         1
       </td>
@@ -8398,19 +7576,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kirlin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Theresa
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-23T04:05:52.696Z"}
@@ -8421,7 +7596,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         43
       </td>
@@ -8431,19 +7605,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schaden
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Molly
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-04-12T07:23:10.017Z"}
@@ -8454,7 +7625,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
@@ -8464,19 +7634,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bechtelar
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Florence
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-16T14:02:35.829Z"}
@@ -8487,7 +7654,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         19
       </td>
@@ -8497,19 +7663,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brown
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Wiley
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-08-29T01:42:14.303Z"}
@@ -8520,7 +7683,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         91
       </td>
@@ -8530,19 +7692,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Flatley
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Moshe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-14T04:52:56.689Z"}
@@ -8553,7 +7712,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         96
       </td>
@@ -8563,19 +7721,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Senger
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zaria
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-11-07T02:17:13.386Z"}
@@ -8586,7 +7741,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         22
       </td>
@@ -8596,19 +7750,16 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Beier
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Eloise
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-19T09:25:33.489Z"}
@@ -8619,7 +7770,6 @@ exports[`Storyshots Template Specialization/ArrayTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         84
       </td>

--- a/src/template-specializations/array-table/array-table.tsx
+++ b/src/template-specializations/array-table/array-table.tsx
@@ -36,6 +36,7 @@ export interface ArrayTableProps<
   idField: K;
   data: Maybe<Maybe<T>[]>;
   configure: ConfigureFunction<T>;
+  noDataSlot?: React.ReactElement;
   Table?: ITable<T>;
   TableHeader?: ITableHeader<T>;
   TableHeaderRow?: ITableHeaderRow<T>;

--- a/src/template-specializations/array-table/array-table.tsx
+++ b/src/template-specializations/array-table/array-table.tsx
@@ -101,7 +101,7 @@ const UnboundArrayTable = <T extends object>({
         idField={idField}
         FieldWrapper={TableBodyCell}
         ItemWrapper={TableBodyRow}
-        Wrapper={TableBody}
+        TemplateWrapper={TableBody}
       />
     </Table>
   );

--- a/src/template-specializations/array-table/array-table.tsx
+++ b/src/template-specializations/array-table/array-table.tsx
@@ -1,33 +1,31 @@
 import React from 'react';
 
 import {
-  Maybe,
+  ArrayTemplate,
   ConfigureFunction,
-  FieldConfigurationProvider,
+  IdType,
+  Maybe,
   Table as BaseTable,
-  Configurer,
   useConfiguredFieldIds,
   useFieldConfiguration,
-  UnboundArrayTemplate,
-  IdType,
 } from '../..';
 
 import {
-  ArrayTableHeader,
-  ArrayTableHeaderRow,
-  ArrayTableHeaderCell,
   ArrayTableBody,
-  ArrayTableBodyRow,
   ArrayTableBodyCell,
+  ArrayTableBodyRow,
+  ArrayTableHeader,
+  ArrayTableHeaderCell,
+  ArrayTableHeaderRow,
 } from './components';
 import {
   ITable,
-  ITableHeader,
-  ITableHeaderRow,
-  ITableHeaderCell,
   ITableBody,
-  ITableBodyRow,
   ITableBodyCell,
+  ITableBodyRow,
+  ITableHeader,
+  ITableHeaderCell,
+  ITableHeaderRow,
   TableHeaderCellProps,
 } from './types';
 
@@ -61,14 +59,34 @@ const ApplyTableHeaderCell = <T extends object>({
   return <Component fieldId={fieldId} {...rest} {...config} />;
 };
 
-type UnboundArrayTableProps<T extends object> = Omit<
-  ArrayTableProps<T>,
-  'configure'
->;
-
-const UnboundArrayTable = <T extends object>({
+const Header = <T extends object>({
   data,
-  idField,
+  TableHeader = ArrayTableHeader,
+  TableHeaderRow = ArrayTableHeaderRow,
+  TableHeaderCell = ArrayTableHeaderCell,
+}: Pick<
+  ArrayTableProps<T>,
+  'data' | 'TableHeader' | 'TableHeaderRow' | 'TableHeaderCell'
+>) => {
+  const fieldIds = useConfiguredFieldIds<T>();
+
+  return (
+    <TableHeader data={data}>
+      <TableHeaderRow data={data}>
+        {fieldIds.map((fieldId) => (
+          <ApplyTableHeaderCell
+            data={data}
+            key={fieldId}
+            fieldId={fieldId}
+            Component={TableHeaderCell}
+          />
+        ))}
+      </TableHeaderRow>
+    </TableHeader>
+  );
+};
+
+export const ArrayTable = <T extends object>({
   Table = BaseTable,
   TableHeader = ArrayTableHeader,
   TableHeaderRow = ArrayTableHeaderRow,
@@ -76,43 +94,24 @@ const UnboundArrayTable = <T extends object>({
   TableBody = ArrayTableBody,
   TableBodyRow = ArrayTableBodyRow,
   TableBodyCell = ArrayTableBodyCell,
-}: UnboundArrayTableProps<T>) => {
-  const fieldIds = useConfiguredFieldIds<T>();
-  if (!data) {
-    return null;
-  }
-
+  ...rest
+}: ArrayTableProps<T>) => {
   return (
-    <Table data={data}>
-      <TableHeader data={data}>
-        <TableHeaderRow data={data}>
-          {fieldIds.map((fieldId) => (
-            <ApplyTableHeaderCell
-              data={data}
-              key={fieldId}
-              fieldId={fieldId}
-              Component={TableHeaderCell}
-            />
-          ))}
-        </TableHeaderRow>
-      </TableHeader>
-      <UnboundArrayTemplate
-        data={data}
-        idField={idField}
-        FieldWrapper={TableBodyCell}
-        ItemWrapper={TableBodyRow}
-        TemplateWrapper={TableBody}
-      />
-    </Table>
+    <ArrayTemplate
+      FieldWrapper={TableBodyCell}
+      ItemWrapper={TableBodyRow}
+      TemplateWrapper={({children, data}) => (
+        <Table data={data}>
+          <Header
+            data={data}
+            TableHeader={TableHeader}
+            TableHeaderRow={TableHeaderRow}
+            TableHeaderCell={TableHeaderCell}
+          />
+          <TableBody data={data}>{children}</TableBody>
+        </Table>
+      )}
+      {...rest}
+    />
   );
 };
-
-export const ArrayTable = <T extends object>({
-  configure: Configure,
-  ...rest
-}: ArrayTableProps<T>) => (
-  <FieldConfigurationProvider>
-    <Configure FieldConfigurer={Configurer} />
-    <UnboundArrayTable {...rest} />
-  </FieldConfigurationProvider>
-);

--- a/src/template-specializations/array-table/components.tsx
+++ b/src/template-specializations/array-table/components.tsx
@@ -45,7 +45,7 @@ export const ArrayTableBody = <T extends object>({
 }: TableBodyProps<T>) => <TableBody {...rest} />;
 
 export const ArrayTableBodyRow = <T extends object>({
-  data,
+  item,
   ...rest
 }: TableBodyRowProps<T>) => <TableBodyRow {...rest} />;
 
@@ -54,7 +54,7 @@ export const ArrayTableBodyCell = <T extends object, K extends IdType<T>>({
   fieldId,
   field,
   value,
-  data,
+  item,
   label,
   keyPath,
   renderer: Renderer,

--- a/src/template-specializations/array-table/types.ts
+++ b/src/template-specializations/array-table/types.ts
@@ -1,5 +1,5 @@
 import {Maybe, IdType, ItemWrapperProps, FieldWrapperProps} from '../..';
-import {WrapperProps} from '../../templates';
+import {TemplateWrapperProps} from '../../templates';
 
 export interface TableProps<T extends object> {
   data: Maybe<Maybe<T>[]>;
@@ -32,7 +32,7 @@ export type ITableHeaderCell<T extends object> = React.ElementType<
   TableHeaderCellProps<T>
 >;
 
-export type TableBodyProps<T extends object> = WrapperProps<Maybe<T>[]>;
+export type TableBodyProps<T extends object> = TemplateWrapperProps<Maybe<T>[]>;
 
 export type ITableBody<T extends object> = React.ElementType<TableBodyProps<T>>;
 

--- a/src/template-specializations/connection-table/__snapshots__/connection-table.stories.storyshot
+++ b/src/template-specializations/connection-table/__snapshots__/connection-table.stories.storyshot
@@ -564,25 +564,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Joshua
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jenkins
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-04-21T09:24:38.262Z"}
@@ -597,25 +593,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lennie
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Krajcik
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         69
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-21T20:24:48.713Z"}
@@ -630,25 +622,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Ophelia
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Olson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         92
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-05T01:04:28.401Z"}
@@ -663,25 +651,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Annabelle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Hamill
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         31
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-10-04T14:50:38.937Z"}
@@ -696,25 +680,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Foster
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Runolfsson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         83
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-30T22:08:33.801Z"}
@@ -729,25 +709,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dayton
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Orn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         90
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-08T08:53:03.410Z"}
@@ -762,25 +738,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Joshua
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Crooks
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         3
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-03-03T07:23:58.735Z"}
@@ -795,25 +767,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jermaine
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bayer
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         10
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-26T10:22:53.934Z"}
@@ -828,25 +796,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Corrine
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Miller
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-26T10:55:45.296Z"}
@@ -861,25 +825,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brice
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schuster
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         70
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-07-02T11:06:23.011Z"}
@@ -894,25 +854,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Chelsey
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kub
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         34
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-18T19:07:03.671Z"}
@@ -927,25 +883,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Mohammad
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Walter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         81
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-25T13:46:21.818Z"}
@@ -960,25 +912,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Polly
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Hagenes
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         32
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-06T20:55:24.609Z"}
@@ -993,25 +941,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Felipe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Quitzon
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         99
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-19T17:47:19.622Z"}
@@ -1026,25 +970,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Malinda
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Anderson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         18
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-24T22:06:01.401Z"}
@@ -1059,25 +999,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Layla
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Luettgen
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         7
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-13T09:50:12.368Z"}
@@ -1092,25 +1028,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dewitt
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brekke
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         11
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-11-02T20:46:49.847Z"}
@@ -1125,25 +1057,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Anna
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kunze
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-01-21T05:32:43.557Z"}
@@ -1158,25 +1086,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Morton
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lowe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         86
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-10-18T01:05:35.725Z"}
@@ -1191,25 +1115,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Marlin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Turner
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-01-03T19:14:42.456Z"}
@@ -1224,25 +1144,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Gerry
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kihn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         50
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-11T23:26:48.223Z"}
@@ -1257,25 +1173,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schuyler
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Thiel
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-13T23:49:34.437Z"}
@@ -1290,25 +1202,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zola
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Cassin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         62
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-12T01:31:04.904Z"}
@@ -1323,25 +1231,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Elaina
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Effertz
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-01T03:50:19.589Z"}
@@ -1356,25 +1260,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dorothea
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Langosh
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         41
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-25T13:06:11.376Z"}
@@ -1389,25 +1289,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Walter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Collins
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         49
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-11T09:50:45.150Z"}
@@ -1422,25 +1318,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lexi
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         White
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         57
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-01-19T11:25:25.523Z"}
@@ -1455,25 +1347,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Barrett
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Stehr
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         18
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-09T21:37:57.360Z"}
@@ -1488,25 +1376,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Clay
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Muller
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         94
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-04-22T09:59:45.171Z"}
@@ -1521,25 +1405,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Omer
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Wolf
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-05T17:02:28.842Z"}
@@ -1554,25 +1434,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bradly
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Williamson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         6
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-03-21T19:15:40.723Z"}
@@ -1587,25 +1463,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Merle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Stark
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         14
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-01-04T01:31:58.194Z"}
@@ -1620,25 +1492,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zelda
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dach
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         5
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-19T04:24:09.772Z"}
@@ -1653,25 +1521,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Turner
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Prohaska
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         28
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-29T01:58:05.913Z"}
@@ -1686,25 +1550,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Savanah
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Grant
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-03T15:09:10.943Z"}
@@ -1719,25 +1579,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Fred
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Koss
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-06-12T03:59:20.701Z"}
@@ -1752,25 +1608,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kelton
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Trantow
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         97
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-24T03:47:22.753Z"}
@@ -1785,25 +1637,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Cicero
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Nienow
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         83
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-27T02:09:38.799Z"}
@@ -1818,25 +1666,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Emie
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Doyle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         3
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-21T01:41:25.229Z"}
@@ -1851,25 +1695,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Garland
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         O'Keefe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         58
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-12T03:04:37.216Z"}
@@ -1884,25 +1724,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kaela
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Runte
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-02-26T13:40:28.643Z"}
@@ -1917,25 +1753,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Josianne
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Carter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         92
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-13T23:32:56.271Z"}
@@ -1950,25 +1782,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Myrtis
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Macejkovic
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         1
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-23T13:30:19.412Z"}
@@ -1983,25 +1811,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Theresa
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kirlin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         43
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-23T04:05:52.696Z"}
@@ -2016,25 +1840,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Molly
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schaden
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-04-12T07:23:10.017Z"}
@@ -2049,25 +1869,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Florence
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bechtelar
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         19
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-16T14:02:35.829Z"}
@@ -2082,25 +1898,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Wiley
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brown
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         91
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-08-29T01:42:14.303Z"}
@@ -2115,25 +1927,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Moshe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Flatley
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         96
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-14T04:52:56.689Z"}
@@ -2148,25 +1956,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zaria
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Senger
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         22
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-11-07T02:17:13.386Z"}
@@ -2181,25 +1985,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Connection Table 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Eloise
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Beier
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         84
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-19T09:25:33.489Z"}
@@ -2785,25 +2585,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Joshua
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jenkins
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-04-21T09:24:38.262Z"}
@@ -2814,7 +2610,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         53620521738
       </td>
@@ -2824,25 +2619,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lennie
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Krajcik
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         69
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-21T20:24:48.713Z"}
@@ -2853,7 +2644,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         19366511287
       </td>
@@ -2863,25 +2653,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Ophelia
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Olson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         92
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-05T01:04:28.401Z"}
@@ -2892,7 +2678,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         57711331599
       </td>
@@ -2902,25 +2687,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Annabelle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Hamill
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         31
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-10-04T14:50:38.937Z"}
@@ -2931,7 +2712,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         7636161063
       </td>
@@ -2941,25 +2721,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Foster
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Runolfsson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         83
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-30T22:08:33.801Z"}
@@ -2970,7 +2746,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         7955486199
       </td>
@@ -2980,25 +2755,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dayton
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Orn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         90
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-08T08:53:03.410Z"}
@@ -3009,7 +2780,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9904016590
       </td>
@@ -3019,25 +2789,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Joshua
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Crooks
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         3
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-03-03T07:23:58.735Z"}
@@ -3048,7 +2814,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         26238961265
       </td>
@@ -3058,25 +2823,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jermaine
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bayer
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         10
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-26T10:22:53.934Z"}
@@ -3087,7 +2848,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         55863426066
       </td>
@@ -3097,25 +2857,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Corrine
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Miller
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-26T10:55:45.296Z"}
@@ -3126,7 +2882,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         39963854704
       </td>
@@ -3136,25 +2891,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brice
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schuster
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         70
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-07-02T11:06:23.011Z"}
@@ -3165,7 +2916,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         47393616989
       </td>
@@ -3175,25 +2925,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Chelsey
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kub
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         34
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-18T19:07:03.671Z"}
@@ -3204,7 +2950,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         38033576329
       </td>
@@ -3214,25 +2959,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Mohammad
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Walter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         81
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-25T13:46:21.818Z"}
@@ -3243,7 +2984,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         19044818182
       </td>
@@ -3253,25 +2993,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Polly
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Hagenes
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         32
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-06T20:55:24.609Z"}
@@ -3282,7 +3018,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         39063875391
       </td>
@@ -3292,25 +3027,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Felipe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Quitzon
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         99
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-19T17:47:19.622Z"}
@@ -3321,7 +3052,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         56441560378
       </td>
@@ -3331,25 +3061,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Malinda
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Anderson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         18
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-24T22:06:01.401Z"}
@@ -3360,7 +3086,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         40096438599
       </td>
@@ -3370,25 +3095,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Layla
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Luettgen
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         7
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-13T09:50:12.368Z"}
@@ -3399,7 +3120,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         33228587632
       </td>
@@ -3409,25 +3129,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dewitt
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brekke
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         11
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-11-02T20:46:49.847Z"}
@@ -3438,7 +3154,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         5109190153
       </td>
@@ -3448,25 +3163,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Anna
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kunze
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-01-21T05:32:43.557Z"}
@@ -3477,7 +3188,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         61410436443
       </td>
@@ -3487,25 +3197,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Morton
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lowe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         86
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-10-18T01:05:35.725Z"}
@@ -3516,7 +3222,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         6476064275
       </td>
@@ -3526,25 +3231,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Marlin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Turner
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-01-03T19:14:42.456Z"}
@@ -3555,7 +3256,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         -242082456
       </td>
@@ -3565,25 +3265,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Gerry
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kihn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         50
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-11T23:26:48.223Z"}
@@ -3594,7 +3290,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         1729991777
       </td>
@@ -3604,25 +3299,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schuyler
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Thiel
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-13T23:49:34.437Z"}
@@ -3633,7 +3324,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         20045425563
       </td>
@@ -3643,25 +3333,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zola
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Cassin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         62
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-12T01:31:04.904Z"}
@@ -3672,7 +3358,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9584935096
       </td>
@@ -3682,25 +3367,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Elaina
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Effertz
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-01T03:50:19.589Z"}
@@ -3711,7 +3392,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         34286980411
       </td>
@@ -3721,25 +3401,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dorothea
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Langosh
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         41
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-25T13:06:11.376Z"}
@@ -3750,7 +3426,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         32180028624
       </td>
@@ -3760,25 +3435,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Walter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Collins
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         49
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-11T09:50:45.150Z"}
@@ -3789,7 +3460,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35993354850
       </td>
@@ -3799,25 +3469,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lexi
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         White
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         57
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-01-19T11:25:25.523Z"}
@@ -3828,7 +3494,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         30026074477
       </td>
@@ -3838,25 +3503,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Barrett
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Stehr
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         18
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-09T21:37:57.360Z"}
@@ -3867,7 +3528,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         33531722640
       </td>
@@ -3877,25 +3537,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Clay
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Muller
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         94
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-04-22T09:59:45.171Z"}
@@ -3906,7 +3562,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         21909614829
       </td>
@@ -3916,25 +3571,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Omer
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Wolf
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-05T17:02:28.842Z"}
@@ -3945,7 +3596,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         41756251158
       </td>
@@ -3955,25 +3605,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bradly
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Williamson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         6
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-03-21T19:15:40.723Z"}
@@ -3984,7 +3630,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         24641059277
       </td>
@@ -3994,25 +3639,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Merle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Stark
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         14
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-01-04T01:31:58.194Z"}
@@ -4023,7 +3664,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         -264718194
       </td>
@@ -4033,25 +3673,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zelda
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dach
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         5
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-19T04:24:09.772Z"}
@@ -4062,7 +3698,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         14326550228
       </td>
@@ -4072,25 +3707,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Turner
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Prohaska
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         28
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-29T01:58:05.913Z"}
@@ -4101,7 +3732,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         252114087
       </td>
@@ -4111,25 +3741,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Savanah
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Grant
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-03T15:09:10.943Z"}
@@ -4140,7 +3766,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         20940649057
       </td>
@@ -4150,25 +3775,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Fred
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Koss
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-06-12T03:59:20.701Z"}
@@ -4179,7 +3800,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         17524839299
       </td>
@@ -4189,25 +3809,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kelton
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Trantow
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         97
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-24T03:47:22.753Z"}
@@ -4218,7 +3834,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         13896757247
       </td>
@@ -4228,25 +3843,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Cicero
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Nienow
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         83
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-27T02:09:38.799Z"}
@@ -4257,7 +3868,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         32046621201
       </td>
@@ -4267,25 +3877,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Emie
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Doyle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         3
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-21T01:41:25.229Z"}
@@ -4296,7 +3902,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         14163514771
       </td>
@@ -4306,25 +3911,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Garland
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         O'Keefe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         58
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-12T03:04:37.216Z"}
@@ -4335,7 +3936,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35931322784
       </td>
@@ -4345,25 +3945,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kaela
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Runte
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-02-26T13:40:28.643Z"}
@@ -4374,7 +3970,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         -4887628643
       </td>
@@ -4384,25 +3979,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Josianne
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Carter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         92
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-13T23:32:56.271Z"}
@@ -4413,7 +4004,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9419223729
       </td>
@@ -4423,25 +4013,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Myrtis
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Macejkovic
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         1
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-23T13:30:19.412Z"}
@@ -4452,7 +4038,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         34943380588
       </td>
@@ -4462,25 +4047,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Theresa
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kirlin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         43
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-23T04:05:52.696Z"}
@@ -4491,7 +4072,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         13982047304
       </td>
@@ -4501,25 +4081,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Molly
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schaden
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-04-12T07:23:10.017Z"}
@@ -4530,7 +4106,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         22783009983
       </td>
@@ -4540,25 +4115,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Florence
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bechtelar
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         19
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-16T14:02:35.829Z"}
@@ -4569,7 +4140,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         1331844171
       </td>
@@ -4579,25 +4149,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Wiley
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brown
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         91
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-08-29T01:42:14.303Z"}
@@ -4608,7 +4174,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         10793865697
       </td>
@@ -4618,25 +4183,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Moshe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Flatley
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         96
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-14T04:52:56.689Z"}
@@ -4647,7 +4208,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         38430423311
       </td>
@@ -4657,25 +4217,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zaria
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Senger
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         22
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-11-07T02:17:13.386Z"}
@@ -4686,7 +4242,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         4743766614
       </td>
@@ -4696,25 +4251,21 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Eloise
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Beier
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         84
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-19T09:25:33.489Z"}
@@ -4725,7 +4276,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Duplicate Fields 1`]
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         37982066511
       </td>
@@ -5398,19 +4948,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Milan
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jenkins
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-04-21T09:24:38.262Z"}
@@ -5421,7 +4968,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9
       </td>
@@ -5431,19 +4977,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Melyna
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Krajcik
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-21T20:24:48.713Z"}
@@ -5454,7 +4997,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         69
       </td>
@@ -5464,19 +5006,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Daisha
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Olson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-05T01:04:28.401Z"}
@@ -5487,7 +5026,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         92
       </td>
@@ -5497,19 +5035,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Coty
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Hamill
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-10-04T14:50:38.937Z"}
@@ -5520,7 +5055,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         31
       </td>
@@ -5530,19 +5064,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kenna
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Runolfsson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-30T22:08:33.801Z"}
@@ -5553,7 +5084,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         83
       </td>
@@ -5563,19 +5093,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Shanny
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Orn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-08T08:53:03.410Z"}
@@ -5586,7 +5113,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         90
       </td>
@@ -5596,19 +5122,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jerome
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Crooks
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-03-03T07:23:58.735Z"}
@@ -5619,7 +5142,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         3
       </td>
@@ -5629,19 +5151,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Leonora
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bayer
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-26T10:22:53.934Z"}
@@ -5652,7 +5171,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         10
       </td>
@@ -5662,19 +5180,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zakary
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Miller
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-26T10:55:45.296Z"}
@@ -5685,7 +5200,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
@@ -5695,19 +5209,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Ken
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schuster
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-07-02T11:06:23.011Z"}
@@ -5718,7 +5229,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         70
       </td>
@@ -5728,19 +5238,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Haylee
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kub
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-18T19:07:03.671Z"}
@@ -5751,7 +5258,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         34
       </td>
@@ -5761,19 +5267,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Curtis
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Walter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-25T13:46:21.818Z"}
@@ -5784,7 +5287,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         81
       </td>
@@ -5794,19 +5296,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Melisa
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Hagenes
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-06T20:55:24.609Z"}
@@ -5817,7 +5316,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         32
       </td>
@@ -5827,19 +5325,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Isabel
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Quitzon
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-19T17:47:19.622Z"}
@@ -5850,7 +5345,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         99
       </td>
@@ -5860,19 +5354,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Wilburn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Anderson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-24T22:06:01.401Z"}
@@ -5883,7 +5374,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         18
       </td>
@@ -5893,19 +5383,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Terrance
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Luettgen
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-13T09:50:12.368Z"}
@@ -5916,7 +5403,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         7
       </td>
@@ -5926,19 +5412,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Miles
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brekke
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-11-02T20:46:49.847Z"}
@@ -5949,7 +5432,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         11
       </td>
@@ -5959,19 +5441,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Skye
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kunze
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-01-21T05:32:43.557Z"}
@@ -5982,7 +5461,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
@@ -5992,19 +5470,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Claudine
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lowe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-10-18T01:05:35.725Z"}
@@ -6015,7 +5490,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         86
       </td>
@@ -6025,19 +5499,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Landen
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Turner
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-01-03T19:14:42.456Z"}
@@ -6048,7 +5519,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
@@ -6058,19 +5528,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Antonia
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kihn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-11T23:26:48.223Z"}
@@ -6081,7 +5548,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         50
       </td>
@@ -6091,19 +5557,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dewitt
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Thiel
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-13T23:49:34.437Z"}
@@ -6114,7 +5577,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9
       </td>
@@ -6124,19 +5586,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Horacio
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Cassin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-12T01:31:04.904Z"}
@@ -6147,7 +5606,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         62
       </td>
@@ -6157,19 +5615,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kathleen
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Effertz
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-01T03:50:19.589Z"}
@@ -6180,7 +5635,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
@@ -6190,19 +5644,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Ella
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Langosh
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-25T13:06:11.376Z"}
@@ -6213,7 +5664,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         41
       </td>
@@ -6223,19 +5673,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jacklyn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Collins
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-11T09:50:45.150Z"}
@@ -6246,7 +5693,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         49
       </td>
@@ -6256,19 +5702,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Loraine
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         White
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-01-19T11:25:25.523Z"}
@@ -6279,7 +5722,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         57
       </td>
@@ -6289,19 +5731,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Christa
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Stehr
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-09T21:37:57.360Z"}
@@ -6312,7 +5751,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         18
       </td>
@@ -6322,19 +5760,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Giovanni
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Muller
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-04-22T09:59:45.171Z"}
@@ -6345,7 +5780,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         94
       </td>
@@ -6355,19 +5789,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Rick
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Wolf
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-05T17:02:28.842Z"}
@@ -6378,7 +5809,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
@@ -6388,19 +5818,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         George
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Williamson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-03-21T19:15:40.723Z"}
@@ -6411,7 +5838,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         6
       </td>
@@ -6421,19 +5847,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jessie
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Stark
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-01-04T01:31:58.194Z"}
@@ -6444,7 +5867,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         14
       </td>
@@ -6454,19 +5876,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Shaylee
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dach
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-19T04:24:09.772Z"}
@@ -6477,7 +5896,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         5
       </td>
@@ -6487,19 +5905,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Carmelo
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Prohaska
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-29T01:58:05.913Z"}
@@ -6510,7 +5925,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         28
       </td>
@@ -6520,19 +5934,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Rebeka
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Grant
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-03T15:09:10.943Z"}
@@ -6543,7 +5954,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
@@ -6553,19 +5963,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kraig
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Koss
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-06-12T03:59:20.701Z"}
@@ -6576,7 +5983,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
@@ -6586,19 +5992,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brock
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Trantow
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-24T03:47:22.753Z"}
@@ -6609,7 +6012,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         97
       </td>
@@ -6619,19 +6021,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Marley
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Nienow
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-27T02:09:38.799Z"}
@@ -6642,7 +6041,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         83
       </td>
@@ -6652,19 +6050,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kyra
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Doyle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-21T01:41:25.229Z"}
@@ -6675,7 +6070,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         3
       </td>
@@ -6685,19 +6079,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Marcel
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         O'Keefe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-12T03:04:37.216Z"}
@@ -6708,7 +6099,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         58
       </td>
@@ -6718,19 +6108,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bianka
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Runte
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-02-26T13:40:28.643Z"}
@@ -6741,7 +6128,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
@@ -6751,19 +6137,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Fredy
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Carter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-13T23:32:56.271Z"}
@@ -6774,7 +6157,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         92
       </td>
@@ -6784,19 +6166,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zelda
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Macejkovic
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-23T13:30:19.412Z"}
@@ -6807,7 +6186,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         1
       </td>
@@ -6817,19 +6195,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Giovani
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kirlin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-23T04:05:52.696Z"}
@@ -6840,7 +6215,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         43
       </td>
@@ -6850,19 +6224,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Griffin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schaden
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-04-12T07:23:10.017Z"}
@@ -6873,7 +6244,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
@@ -6883,19 +6253,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Nathaniel
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bechtelar
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-16T14:02:35.829Z"}
@@ -6906,7 +6273,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         19
       </td>
@@ -6916,19 +6282,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Amiya
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brown
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-08-29T01:42:14.303Z"}
@@ -6939,7 +6302,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         91
       </td>
@@ -6949,19 +6311,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Vivian
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Flatley
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-14T04:52:56.689Z"}
@@ -6972,7 +6331,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         96
       </td>
@@ -6982,19 +6340,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lysanne
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Senger
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-11-07T02:17:13.386Z"}
@@ -7005,7 +6360,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         22
       </td>
@@ -7015,19 +6369,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Ena
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Beier
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-19T09:25:33.489Z"}
@@ -7038,7 +6389,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Nested Data 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         84
       </td>
@@ -7611,19 +6961,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jenkins
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Joshua
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-04-21T09:24:38.262Z"}
@@ -7634,7 +6981,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9
       </td>
@@ -7644,19 +6990,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Krajcik
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lennie
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-21T20:24:48.713Z"}
@@ -7667,7 +7010,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         69
       </td>
@@ -7677,19 +7019,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Olson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Ophelia
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-05T01:04:28.401Z"}
@@ -7700,7 +7039,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         92
       </td>
@@ -7710,19 +7048,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Hamill
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Annabelle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-10-04T14:50:38.937Z"}
@@ -7733,7 +7068,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         31
       </td>
@@ -7743,19 +7077,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Runolfsson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Foster
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-30T22:08:33.801Z"}
@@ -7766,7 +7097,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         83
       </td>
@@ -7776,19 +7106,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Orn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dayton
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-08T08:53:03.410Z"}
@@ -7799,7 +7126,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         90
       </td>
@@ -7809,19 +7135,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Crooks
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Joshua
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-03-03T07:23:58.735Z"}
@@ -7832,7 +7155,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         3
       </td>
@@ -7842,19 +7164,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bayer
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Jermaine
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-26T10:22:53.934Z"}
@@ -7865,7 +7184,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         10
       </td>
@@ -7875,19 +7193,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Miller
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Corrine
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-26T10:55:45.296Z"}
@@ -7898,7 +7213,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
@@ -7908,19 +7222,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schuster
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brice
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-07-02T11:06:23.011Z"}
@@ -7931,7 +7242,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         70
       </td>
@@ -7941,19 +7251,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kub
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Chelsey
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-18T19:07:03.671Z"}
@@ -7964,7 +7271,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         34
       </td>
@@ -7974,19 +7280,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Walter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Mohammad
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-25T13:46:21.818Z"}
@@ -7997,7 +7300,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         81
       </td>
@@ -8007,19 +7309,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Hagenes
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Polly
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-06T20:55:24.609Z"}
@@ -8030,7 +7329,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         32
       </td>
@@ -8040,19 +7338,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Quitzon
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Felipe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-03-19T17:47:19.622Z"}
@@ -8063,7 +7358,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         99
       </td>
@@ -8073,19 +7367,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Anderson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Malinda
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-24T22:06:01.401Z"}
@@ -8096,7 +7387,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         18
       </td>
@@ -8106,19 +7396,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Luettgen
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Layla
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-13T09:50:12.368Z"}
@@ -8129,7 +7416,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         7
       </td>
@@ -8139,19 +7425,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brekke
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dewitt
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-11-02T20:46:49.847Z"}
@@ -8162,7 +7445,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         11
       </td>
@@ -8172,19 +7454,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kunze
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Anna
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-01-21T05:32:43.557Z"}
@@ -8195,7 +7474,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
@@ -8205,19 +7483,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lowe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Morton
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-10-18T01:05:35.725Z"}
@@ -8228,7 +7503,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         86
       </td>
@@ -8238,19 +7512,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Turner
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Marlin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-01-03T19:14:42.456Z"}
@@ -8261,7 +7532,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
@@ -8271,19 +7541,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kihn
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Gerry
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-11T23:26:48.223Z"}
@@ -8294,7 +7561,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         50
       </td>
@@ -8304,19 +7570,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Thiel
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schuyler
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-13T23:49:34.437Z"}
@@ -8327,7 +7590,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         9
       </td>
@@ -8337,19 +7599,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Cassin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zola
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-12T01:31:04.904Z"}
@@ -8360,7 +7619,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         62
       </td>
@@ -8370,19 +7628,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Effertz
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Elaina
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-01T03:50:19.589Z"}
@@ -8393,7 +7648,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
@@ -8403,19 +7657,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Langosh
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dorothea
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-25T13:06:11.376Z"}
@@ -8426,7 +7677,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         41
       </td>
@@ -8436,19 +7686,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Collins
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Walter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-11T09:50:45.150Z"}
@@ -8459,7 +7706,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         49
       </td>
@@ -8469,19 +7715,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         White
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Lexi
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-01-19T11:25:25.523Z"}
@@ -8492,7 +7735,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         57
       </td>
@@ -8502,19 +7744,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Stehr
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Barrett
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-09T21:37:57.360Z"}
@@ -8525,7 +7764,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         18
       </td>
@@ -8535,19 +7773,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Muller
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Clay
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-04-22T09:59:45.171Z"}
@@ -8558,7 +7793,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         94
       </td>
@@ -8568,19 +7802,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Wolf
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Omer
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-09-05T17:02:28.842Z"}
@@ -8591,7 +7822,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
@@ -8601,19 +7831,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Williamson
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bradly
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-03-21T19:15:40.723Z"}
@@ -8624,7 +7851,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         6
       </td>
@@ -8634,19 +7860,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Stark
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Merle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-01-04T01:31:58.194Z"}
@@ -8657,7 +7880,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         14
       </td>
@@ -8667,19 +7889,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Dach
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zelda
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-19T04:24:09.772Z"}
@@ -8690,7 +7909,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         5
       </td>
@@ -8700,19 +7918,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Prohaska
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Turner
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-29T01:58:05.913Z"}
@@ -8723,7 +7938,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         28
       </td>
@@ -8733,19 +7947,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Grant
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Savanah
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-05-03T15:09:10.943Z"}
@@ -8756,7 +7967,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         35
       </td>
@@ -8766,19 +7976,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Koss
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Fred
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-06-12T03:59:20.701Z"}
@@ -8789,7 +7996,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         68
       </td>
@@ -8799,19 +8005,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Trantow
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kelton
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-24T03:47:22.753Z"}
@@ -8822,7 +8025,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         97
       </td>
@@ -8832,19 +8034,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Nienow
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Cicero
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-12-27T02:09:38.799Z"}
@@ -8855,7 +8054,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         83
       </td>
@@ -8865,19 +8063,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Doyle
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Emie
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-21T01:41:25.229Z"}
@@ -8888,7 +8083,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         3
       </td>
@@ -8898,19 +8092,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         O'Keefe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Garland
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-12T03:04:37.216Z"}
@@ -8921,7 +8112,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         58
       </td>
@@ -8931,19 +8121,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Runte
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kaela
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2021-02-26T13:40:28.643Z"}
@@ -8954,7 +8141,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
@@ -8964,19 +8150,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Carter
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Josianne
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-09-13T23:32:56.271Z"}
@@ -8987,7 +8170,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         92
       </td>
@@ -8997,19 +8179,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Macejkovic
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Myrtis
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-11-23T13:30:19.412Z"}
@@ -9020,7 +8199,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         1
       </td>
@@ -9030,19 +8208,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Kirlin
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Theresa
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-07-23T04:05:52.696Z"}
@@ -9053,7 +8228,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         43
       </td>
@@ -9063,19 +8237,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Schaden
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Molly
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-04-12T07:23:10.017Z"}
@@ -9086,7 +8257,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         88
       </td>
@@ -9096,19 +8266,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Bechtelar
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Florence
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-12-16T14:02:35.829Z"}
@@ -9119,7 +8286,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         19
       </td>
@@ -9129,19 +8295,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Brown
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Wiley
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-08-29T01:42:14.303Z"}
@@ -9152,7 +8315,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         91
       </td>
@@ -9162,19 +8324,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Flatley
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Moshe
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-14T04:52:56.689Z"}
@@ -9185,7 +8344,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         96
       </td>
@@ -9195,19 +8353,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Senger
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Zaria
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2020-11-07T02:17:13.386Z"}
@@ -9218,7 +8373,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         22
       </td>
@@ -9228,19 +8382,16 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
     >
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Beier
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         Eloise
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         <time
           dateTime={"2019-10-19T09:25:33.489Z"}
@@ -9251,7 +8402,6 @@ exports[`Storyshots Template Specialization/ConnectionTable Out Of Order 1`] = `
       </td>
       <td
         className="clc-table__body-cell"
-        idField="id"
       >
         84
       </td>

--- a/src/template-specializations/connection-table/components.tsx
+++ b/src/template-specializations/connection-table/components.tsx
@@ -47,7 +47,7 @@ export const ConnectionTableBody = <N extends NodeLike>({
 
 export const ConnectionTableBodyRow = <N extends NodeLike>({
   // connection,
-  data,
+  item,
   ...rest
 }: TableBodyRowProps<N>) => <TableBodyRow {...rest} />;
 
@@ -60,7 +60,7 @@ export const ConnectionTableBodyCell = <
   fieldId,
   field,
   value,
-  data,
+  item,
   label,
   keyPath,
   renderer: Renderer,

--- a/src/template-specializations/connection-table/connection-table.tsx
+++ b/src/template-specializations/connection-table/connection-table.tsx
@@ -96,7 +96,7 @@ const UnboundConnectionTable = <N extends NodeLike, PI>({
         connection={connection}
         FieldWrapper={TableBodyCell}
         ItemWrapper={TableBodyRow}
-        Wrapper={TableBody}
+        TemplateWrapper={TableBody}
       />
     </Table>
   );

--- a/src/template-specializations/connection-table/connection-table.tsx
+++ b/src/template-specializations/connection-table/connection-table.tsx
@@ -33,6 +33,7 @@ import {
 export interface ConnectionTableProps<N extends NodeLike, PI> {
   connection: Maybe<ConnectionLike<N, PI>>;
   configure: ConfigureFunction<N>;
+  noDataSlot?: React.ReactElement;
   Table?: ITable<N, PI>;
   TableHeader?: ITableHeader<N, PI>;
   TableHeaderRow?: ITableHeaderRow<N, PI>;

--- a/src/template-specializations/connection-table/connection-table.tsx
+++ b/src/template-specializations/connection-table/connection-table.tsx
@@ -1,34 +1,32 @@
 import React from 'react';
 
 import {
-  ConnectionLike,
-  Maybe,
   ConfigureFunction,
+  ConnectionLike,
+  ConnectionTemplate,
+  Maybe,
   NodeLike,
-  FieldConfigurationProvider,
   Table as BaseTable,
-  Configurer,
-  UnboundConnectionTemplate,
   useConfiguredFieldIds,
   useFieldConfiguration,
 } from '../..';
 
 import {
-  ConnectionTableHeader,
-  ConnectionTableHeaderRow,
-  ConnectionTableHeaderCell,
   ConnectionTableBody,
-  ConnectionTableBodyRow,
   ConnectionTableBodyCell,
+  ConnectionTableBodyRow,
+  ConnectionTableHeader,
+  ConnectionTableHeaderCell,
+  ConnectionTableHeaderRow,
 } from './components';
 import {
   ITable,
-  ITableHeader,
-  ITableHeaderRow,
-  ITableHeaderCell,
   ITableBody,
-  ITableBodyRow,
   ITableBodyCell,
+  ITableBodyRow,
+  ITableHeader,
+  ITableHeaderCell,
+  ITableHeaderRow,
   TableHeaderCellProps,
 } from './types';
 
@@ -58,12 +56,34 @@ const ApplyTableHeaderCell = <N extends NodeLike, PI>({
   return <Component fieldId={fieldId} {...rest} {...config} />;
 };
 
-type WrapDataProps<N extends NodeLike, PI> = Omit<
+const Header = <N extends NodeLike, PI>({
+  connection,
+  TableHeader = ConnectionTableHeader,
+  TableHeaderRow = ConnectionTableHeaderRow,
+  TableHeaderCell = ConnectionTableHeaderCell,
+}: Pick<
   ConnectionTableProps<N, PI>,
-  'configure'
->;
+  'connection' | 'TableHeader' | 'TableHeaderRow' | 'TableHeaderCell'
+>) => {
+  const fieldIds = useConfiguredFieldIds<N>();
 
-const UnboundConnectionTable = <N extends NodeLike, PI>({
+  return (
+    <TableHeader connection={connection}>
+      <TableHeaderRow connection={connection}>
+        {fieldIds.map((fieldId) => (
+          <ApplyTableHeaderCell
+            connection={connection}
+            key={fieldId}
+            fieldId={fieldId}
+            Component={TableHeaderCell}
+          />
+        ))}
+      </TableHeaderRow>
+    </TableHeader>
+  );
+};
+
+export const ConnectionTable = <N extends NodeLike, PI>({
   connection,
   Table = BaseTable,
   TableHeader = ConnectionTableHeader,
@@ -72,42 +92,23 @@ const UnboundConnectionTable = <N extends NodeLike, PI>({
   TableBody = ConnectionTableBody,
   TableBodyRow = ConnectionTableBodyRow,
   TableBodyCell = ConnectionTableBodyCell,
-}: WrapDataProps<N, PI>) => {
-  const fieldIds = useConfiguredFieldIds<N>();
-  if (!connection) {
-    return null;
-  }
-
-  return (
-    <Table connection={connection}>
-      <TableHeader connection={connection}>
-        <TableHeaderRow connection={connection}>
-          {fieldIds.map((fieldId) => (
-            <ApplyTableHeaderCell
-              connection={connection}
-              key={fieldId}
-              fieldId={fieldId}
-              Component={TableHeaderCell}
-            />
-          ))}
-        </TableHeaderRow>
-      </TableHeader>
-      <UnboundConnectionTemplate
-        connection={connection}
-        FieldWrapper={TableBodyCell}
-        ItemWrapper={TableBodyRow}
-        TemplateWrapper={TableBody}
-      />
-    </Table>
-  );
-};
-
-export const ConnectionTable = <N extends NodeLike, PI>({
-  configure: Configure,
   ...rest
 }: ConnectionTableProps<N, PI>) => (
-  <FieldConfigurationProvider>
-    <Configure FieldConfigurer={Configurer} />
-    <UnboundConnectionTable {...rest} />
-  </FieldConfigurationProvider>
+  <ConnectionTemplate
+    connection={connection}
+    FieldWrapper={TableBodyCell}
+    ItemWrapper={TableBodyRow}
+    TemplateWrapper={({children, data}) => (
+      <Table connection={connection}>
+        <Header
+          connection={connection}
+          TableHeader={TableHeader}
+          TableHeaderRow={TableHeaderRow}
+          TableHeaderCell={TableHeaderCell}
+        />
+        <TableBody data={data}>{children}</TableBody>
+      </Table>
+    )}
+    {...rest}
+  />
 );

--- a/src/template-specializations/connection-table/types.ts
+++ b/src/template-specializations/connection-table/types.ts
@@ -6,7 +6,7 @@ import {
   ItemWrapperProps,
   FieldWrapperProps,
 } from '../..';
-import {WrapperProps} from '../../templates';
+import {TemplateWrapperProps} from '../../templates';
 
 export interface TableProps<N extends NodeLike, PI> {
   connection: Maybe<ConnectionLike<N, PI>>;
@@ -41,7 +41,9 @@ export type ITableHeaderCell<N extends NodeLike, PI> = React.ElementType<
   TableHeaderCellProps<N, PI>
 >;
 
-export type TableBodyProps<N extends NodeLike> = WrapperProps<Maybe<N>[]>;
+export type TableBodyProps<N extends NodeLike> = TemplateWrapperProps<
+  Maybe<N>[]
+>;
 
 export type ITableBody<N extends NodeLike> = React.ElementType<
   TableBodyProps<N>

--- a/src/template-specializations/object-description/object-description.tsx
+++ b/src/template-specializations/object-description/object-description.tsx
@@ -32,7 +32,7 @@ export const UnboundObjectDescription = <T extends object>({
   <>
     <UnboundObjectTemplate
       data={data}
-      Wrapper={Wrapper}
+      TemplateWrapper={Wrapper}
       FieldWrapper={FieldWrapper}
     />
   </>

--- a/src/template-specializations/object-description/object-description.tsx
+++ b/src/template-specializations/object-description/object-description.tsx
@@ -1,51 +1,34 @@
 import React from 'react';
 
-import {Configurer, FieldConfigurationProvider, Maybe} from '../..';
-import {ConfigureFunction, UnboundObjectTemplate} from '../../templates';
+import {Maybe} from '../..';
+import {ConfigureFunction, ObjectTemplate} from '../../templates';
 
 import {
   ObjectDescriptionFieldWrapper,
   ObjectDescriptionWrapper,
 } from './components';
 import {
-  IObjectDescriptionWrapper,
   IObjectDescriptionFieldWrapper,
+  IObjectDescriptionWrapper,
 } from './types';
 
 export interface ObjectDescriptionProps<T extends object> {
   data: Maybe<T>;
   configure: ConfigureFunction<T>;
-  Wrapper?: IObjectDescriptionWrapper<T>;
+  TemplateWrapper?: IObjectDescriptionWrapper<T>;
   FieldWrapper?: IObjectDescriptionFieldWrapper<T>;
 }
 
-export type UnboundObjectDescriptionProps<T extends object> = Omit<
-  ObjectDescriptionProps<T>,
-  'configure'
->;
-
-export const UnboundObjectDescription = <T extends object>({
-  data,
-  Wrapper = ObjectDescriptionWrapper,
-  FieldWrapper = ObjectDescriptionFieldWrapper,
-}: UnboundObjectDescriptionProps<T>) => (
-  <>
-    <UnboundObjectTemplate
-      data={data}
-      TemplateWrapper={Wrapper}
-      FieldWrapper={FieldWrapper}
-    />
-  </>
-);
-
 export const ObjectDescription = <T extends object>({
-  configure: Configure,
+  TemplateWrapper = ObjectDescriptionWrapper,
+  FieldWrapper = ObjectDescriptionFieldWrapper,
   ...rest
 }: ObjectDescriptionProps<T>) => (
   <>
-    <FieldConfigurationProvider>
-      <Configure FieldConfigurer={Configurer} />
-      <UnboundObjectDescription {...rest} />
-    </FieldConfigurationProvider>
+    <ObjectTemplate
+      TemplateWrapper={TemplateWrapper}
+      FieldWrapper={FieldWrapper}
+      {...rest}
+    />
   </>
 );

--- a/src/template-specializations/object-description/object-description.tsx
+++ b/src/template-specializations/object-description/object-description.tsx
@@ -15,6 +15,7 @@ import {
 export interface ObjectDescriptionProps<T extends object> {
   data: Maybe<T>;
   configure: ConfigureFunction<T>;
+  noDataSlot?: React.ReactElement;
   TemplateWrapper?: IObjectDescriptionWrapper<T>;
   FieldWrapper?: IObjectDescriptionFieldWrapper<T>;
 }

--- a/src/template-specializations/object-description/types.ts
+++ b/src/template-specializations/object-description/types.ts
@@ -1,11 +1,10 @@
 import React from 'react';
 
 import {IdType, Maybe} from '../..';
-import {FieldWrapperProps, WrapperProps} from '../../templates';
+import {FieldWrapperProps, TemplateWrapperProps} from '../../templates';
 
-export type ObjectDescriptionWrapperProps<T extends object> = WrapperProps<
-  Maybe<T>
->;
+export type ObjectDescriptionWrapperProps<T extends object> =
+  TemplateWrapperProps<Maybe<T>>;
 
 export type IObjectDescriptionWrapper<T extends object> = React.ElementType<
   ObjectDescriptionWrapperProps<T>

--- a/src/templates/array-template/__snapshots__/array-template.stories.storyshot
+++ b/src/templates/array-template/__snapshots__/array-template.stories.storyshot
@@ -150,6 +150,176 @@ exports[`Storyshots Templates/ArrayTemplate Array Template 1`] = `
 </ul>
 `;
 
+exports[`Storyshots Templates/ArrayTemplate Custom Field Wrapper 1`] = `
+<ul>
+  <li>
+    <ul>
+      <div
+        style={
+          Object {
+            "textTransform": "uppercase",
+          }
+        }
+      >
+        Joshua
+      </div>
+      <li>
+        Last Name
+        : 
+        Jenkins
+      </li>
+      <li>
+        Age
+        : 
+        9
+      </li>
+      <li>
+        Sign Up Date
+        : 
+        <time
+          dateTime={"2019-04-21T09:24:38.262Z"}
+          title="2019-04-21T09:24:38+00:00"
+        >
+          April 21, 2019
+        </time>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <ul>
+      <div
+        style={
+          Object {
+            "textTransform": "uppercase",
+          }
+        }
+      >
+        Lennie
+      </div>
+      <li>
+        Last Name
+        : 
+        Krajcik
+      </li>
+      <li>
+        Age
+        : 
+        69
+      </li>
+      <li>
+        Sign Up Date
+        : 
+        <time
+          dateTime={"2020-05-21T20:24:48.713Z"}
+          title="2020-05-21T20:24:48+00:00"
+        >
+          May 21, 2020
+        </time>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <ul>
+      <div
+        style={
+          Object {
+            "textTransform": "uppercase",
+          }
+        }
+      >
+        Ophelia
+      </div>
+      <li>
+        Last Name
+        : 
+        Olson
+      </li>
+      <li>
+        Age
+        : 
+        92
+      </li>
+      <li>
+        Sign Up Date
+        : 
+        <time
+          dateTime={"2019-03-05T01:04:28.401Z"}
+          title="2019-03-05T01:04:28+00:00"
+        >
+          March 5, 2019
+        </time>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <ul>
+      <div
+        style={
+          Object {
+            "textTransform": "uppercase",
+          }
+        }
+      >
+        Annabelle
+      </div>
+      <li>
+        Last Name
+        : 
+        Hamill
+      </li>
+      <li>
+        Age
+        : 
+        31
+      </li>
+      <li>
+        Sign Up Date
+        : 
+        <time
+          dateTime={"2020-10-04T14:50:38.937Z"}
+          title="2020-10-04T14:50:38+00:00"
+        >
+          October 4, 2020
+        </time>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <ul>
+      <div
+        style={
+          Object {
+            "textTransform": "uppercase",
+          }
+        }
+      >
+        Foster
+      </div>
+      <li>
+        Last Name
+        : 
+        Runolfsson
+      </li>
+      <li>
+        Age
+        : 
+        83
+      </li>
+      <li>
+        Sign Up Date
+        : 
+        <time
+          dateTime={"2020-09-30T22:08:33.801Z"}
+          title="2020-09-30T22:08:33+00:00"
+        >
+          September 30, 2020
+        </time>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
 exports[`Storyshots Templates/ArrayTemplate Default No Op 1`] = `
 Array [
   "Joshua",

--- a/src/templates/array-template/__snapshots__/array-template.stories.storyshot
+++ b/src/templates/array-template/__snapshots__/array-template.stories.storyshot
@@ -375,6 +375,8 @@ exports[`Storyshots Templates/ArrayTemplate Duplicate Fields 1`] = `
 </ul>
 `;
 
+exports[`Storyshots Templates/ArrayTemplate Empty Data 1`] = `"No data received"`;
+
 exports[`Storyshots Templates/ArrayTemplate Nested Data 1`] = `
 <ul>
   <li>
@@ -524,6 +526,8 @@ exports[`Storyshots Templates/ArrayTemplate Nested Data 1`] = `
   </li>
 </ul>
 `;
+
+exports[`Storyshots Templates/ArrayTemplate Null Data 1`] = `"No data received"`;
 
 exports[`Storyshots Templates/ArrayTemplate Out Of Order 1`] = `
 <ul>

--- a/src/templates/array-template/__snapshots__/array-template.stories.storyshot
+++ b/src/templates/array-template/__snapshots__/array-template.stories.storyshot
@@ -674,3 +674,153 @@ exports[`Storyshots Templates/ArrayTemplate Out Of Order 1`] = `
   </li>
 </ul>
 `;
+
+exports[`Storyshots Templates/ArrayTemplate Raw Html Wrappers 1`] = `
+<ul
+  data={
+    Array [
+      Object {
+        "age": 9,
+        "firstName": "Joshua",
+        "id": "1c887ce7-df33-419f-ba65-d255867e20db",
+        "lastName": "Jenkins",
+        "signUpDate": 2019-04-21T09:24:38.262Z,
+      },
+      Object {
+        "age": 69,
+        "firstName": "Lennie",
+        "id": "4f6d8ab9-d312-48c9-837a-ef7fe202505b",
+        "lastName": "Krajcik",
+        "signUpDate": 2020-05-21T20:24:48.713Z,
+      },
+      Object {
+        "age": 92,
+        "firstName": "Ophelia",
+        "id": "0759f49b-a6d1-435b-b0db-53ead69330c3",
+        "lastName": "Olson",
+        "signUpDate": 2019-03-05T01:04:28.401Z,
+      },
+      Object {
+        "age": 31,
+        "firstName": "Annabelle",
+        "id": "b19d2e3f-5a5f-4ed3-a61b-862cf60e8cf3",
+        "lastName": "Hamill",
+        "signUpDate": 2020-10-04T14:50:38.937Z,
+      },
+      Object {
+        "age": 83,
+        "firstName": "Foster",
+        "id": "08db873e-9e2a-4d1c-a948-4c1ff3e31709",
+        "lastName": "Runolfsson",
+        "signUpDate": 2020-09-30T22:08:33.801Z,
+      },
+    ]
+  }
+>
+  <li>
+    <ul>
+      <li>
+        Joshua
+      </li>
+      <li>
+        Jenkins
+      </li>
+      <li>
+        9
+      </li>
+      <li>
+        <time
+          dateTime={"2019-04-21T09:24:38.262Z"}
+          title="2019-04-21T09:24:38+00:00"
+        >
+          April 21, 2019
+        </time>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <ul>
+      <li>
+        Lennie
+      </li>
+      <li>
+        Krajcik
+      </li>
+      <li>
+        69
+      </li>
+      <li>
+        <time
+          dateTime={"2020-05-21T20:24:48.713Z"}
+          title="2020-05-21T20:24:48+00:00"
+        >
+          May 21, 2020
+        </time>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <ul>
+      <li>
+        Ophelia
+      </li>
+      <li>
+        Olson
+      </li>
+      <li>
+        92
+      </li>
+      <li>
+        <time
+          dateTime={"2019-03-05T01:04:28.401Z"}
+          title="2019-03-05T01:04:28+00:00"
+        >
+          March 5, 2019
+        </time>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <ul>
+      <li>
+        Annabelle
+      </li>
+      <li>
+        Hamill
+      </li>
+      <li>
+        31
+      </li>
+      <li>
+        <time
+          dateTime={"2020-10-04T14:50:38.937Z"}
+          title="2020-10-04T14:50:38+00:00"
+        >
+          October 4, 2020
+        </time>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <ul>
+      <li>
+        Foster
+      </li>
+      <li>
+        Runolfsson
+      </li>
+      <li>
+        83
+      </li>
+      <li>
+        <time
+          dateTime={"2020-09-30T22:08:33.801Z"}
+          title="2020-09-30T22:08:33+00:00"
+        >
+          September 30, 2020
+        </time>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;

--- a/src/templates/array-template/__snapshots__/array-template.stories.storyshot
+++ b/src/templates/array-template/__snapshots__/array-template.stories.storyshot
@@ -676,47 +676,7 @@ exports[`Storyshots Templates/ArrayTemplate Out Of Order 1`] = `
 `;
 
 exports[`Storyshots Templates/ArrayTemplate Raw Html Wrappers 1`] = `
-<ul
-  data={
-    Array [
-      Object {
-        "age": 9,
-        "firstName": "Joshua",
-        "id": "1c887ce7-df33-419f-ba65-d255867e20db",
-        "lastName": "Jenkins",
-        "signUpDate": 2019-04-21T09:24:38.262Z,
-      },
-      Object {
-        "age": 69,
-        "firstName": "Lennie",
-        "id": "4f6d8ab9-d312-48c9-837a-ef7fe202505b",
-        "lastName": "Krajcik",
-        "signUpDate": 2020-05-21T20:24:48.713Z,
-      },
-      Object {
-        "age": 92,
-        "firstName": "Ophelia",
-        "id": "0759f49b-a6d1-435b-b0db-53ead69330c3",
-        "lastName": "Olson",
-        "signUpDate": 2019-03-05T01:04:28.401Z,
-      },
-      Object {
-        "age": 31,
-        "firstName": "Annabelle",
-        "id": "b19d2e3f-5a5f-4ed3-a61b-862cf60e8cf3",
-        "lastName": "Hamill",
-        "signUpDate": 2020-10-04T14:50:38.937Z,
-      },
-      Object {
-        "age": 83,
-        "firstName": "Foster",
-        "id": "08db873e-9e2a-4d1c-a948-4c1ff3e31709",
-        "lastName": "Runolfsson",
-        "signUpDate": 2020-09-30T22:08:33.801Z,
-      },
-    ]
-  }
->
+<ul>
   <li>
     <ul>
       <li>

--- a/src/templates/array-template/__snapshots__/array-template.stories.storyshot
+++ b/src/templates/array-template/__snapshots__/array-template.stories.storyshot
@@ -150,6 +150,56 @@ exports[`Storyshots Templates/ArrayTemplate Array Template 1`] = `
 </ul>
 `;
 
+exports[`Storyshots Templates/ArrayTemplate Default No Op 1`] = `
+Array [
+  "Joshua",
+  "Jenkins",
+  "9",
+  <time
+    dateTime={"2019-04-21T09:24:38.262Z"}
+    title="2019-04-21T09:24:38+00:00"
+  >
+    April 21, 2019
+  </time>,
+  "Lennie",
+  "Krajcik",
+  "69",
+  <time
+    dateTime={"2020-05-21T20:24:48.713Z"}
+    title="2020-05-21T20:24:48+00:00"
+  >
+    May 21, 2020
+  </time>,
+  "Ophelia",
+  "Olson",
+  "92",
+  <time
+    dateTime={"2019-03-05T01:04:28.401Z"}
+    title="2019-03-05T01:04:28+00:00"
+  >
+    March 5, 2019
+  </time>,
+  "Annabelle",
+  "Hamill",
+  "31",
+  <time
+    dateTime={"2020-10-04T14:50:38.937Z"}
+    title="2020-10-04T14:50:38+00:00"
+  >
+    October 4, 2020
+  </time>,
+  "Foster",
+  "Runolfsson",
+  "83",
+  <time
+    dateTime={"2020-09-30T22:08:33.801Z"}
+    title="2020-09-30T22:08:33+00:00"
+  >
+    September 30, 2020
+  </time>,
+]
+`;
+
 exports[`Storyshots Templates/ArrayTemplate Duplicate Fields 1`] = `
 <ul>
   <li>

--- a/src/templates/array-template/array-template.spec.tsx
+++ b/src/templates/array-template/array-template.spec.tsx
@@ -27,7 +27,7 @@ describe('ArrayTemplate', () => {
           </>
         )}
         ItemWrapper={ItemWrapper}
-        Wrapper={Wrapper}
+        TemplateWrapper={Wrapper}
         FieldWrapper={FieldWrapper}
       />
     );
@@ -58,7 +58,7 @@ describe('ArrayTemplate', () => {
           </>
         )}
         ItemWrapper={ItemWrapper}
-        Wrapper={Wrapper}
+        TemplateWrapper={Wrapper}
         FieldWrapper={FieldWrapper}
       />
     );
@@ -89,7 +89,7 @@ describe('ArrayTemplate', () => {
           </>
         )}
         ItemWrapper={ItemWrapper}
-        Wrapper={Wrapper}
+        TemplateWrapper={Wrapper}
         FieldWrapper={FieldWrapper}
       />
     );
@@ -123,7 +123,7 @@ describe('ArrayTemplate', () => {
           </>
         )}
         ItemWrapper={ItemWrapper}
-        Wrapper={Wrapper}
+        TemplateWrapper={Wrapper}
         FieldWrapper={FieldWrapper}
       />
     );
@@ -152,7 +152,7 @@ describe('ArrayTemplate', () => {
           </>
         )}
         ItemWrapper={ItemWrapper}
-        Wrapper={Wrapper}
+        TemplateWrapper={Wrapper}
         FieldWrapper={FieldWrapper}
       />
     );

--- a/src/templates/array-template/array-template.stories.tsx
+++ b/src/templates/array-template/array-template.stories.tsx
@@ -23,7 +23,7 @@ export const arrayTemplate = () => (
       </>
     )}
     ItemWrapper={ItemWrapper}
-    Wrapper={Wrapper}
+    TemplateWrapper={Wrapper}
     FieldWrapper={FieldWrapper}
   />
 );
@@ -41,7 +41,7 @@ export const outOfOrder = () => (
       </>
     )}
     ItemWrapper={ItemWrapper}
-    Wrapper={Wrapper}
+    TemplateWrapper={Wrapper}
     FieldWrapper={FieldWrapper}
   />
 );
@@ -66,7 +66,7 @@ export const duplicateFields = () => (
       </>
     )}
     ItemWrapper={ItemWrapper}
-    Wrapper={Wrapper}
+    TemplateWrapper={Wrapper}
     FieldWrapper={FieldWrapper}
   />
 );
@@ -91,7 +91,7 @@ export const nestedData = () => (
       </>
     )}
     ItemWrapper={ItemWrapper}
-    Wrapper={Wrapper}
+    TemplateWrapper={Wrapper}
     FieldWrapper={FieldWrapper}
   />
 );

--- a/src/templates/array-template/array-template.stories.tsx
+++ b/src/templates/array-template/array-template.stories.tsx
@@ -95,3 +95,26 @@ export const nestedData = () => (
     FieldWrapper={FieldWrapper}
   />
 );
+
+export const defaultNoOp = () => (
+  <ArrayTemplate
+    idField="id"
+    data={makeSimplePeople(5)}
+    configure={({FieldConfigurer}) => (
+      <>
+        <FieldConfigurer field="firstName" />
+        <FieldConfigurer field="lastName" />
+        <FieldConfigurer field="age" />
+        <FieldConfigurer field="signUpDate" />
+      </>
+    )}
+  />
+);
+defaultNoOp.parameters = {
+  docs: {
+    description: {
+      story:
+        "If Wrappers are not provided, the Template will still render _something_. It almost certainly won't be pretty, but after using Templates in the wild, it became clear that a lost of specialization might not need full customizations, so adding noop-rendering makes a lot of implementations much easier.",
+    },
+  },
+};

--- a/src/templates/array-template/array-template.stories.tsx
+++ b/src/templates/array-template/array-template.stories.tsx
@@ -118,3 +118,25 @@ defaultNoOp.parameters = {
     },
   },
 };
+
+export const rawHtmlWrappers = () => (
+  <ArrayTemplate
+    idField="id"
+    data={makeSimplePeople(5)}
+    configure={({FieldConfigurer}) => (
+      <>
+        <FieldConfigurer field="firstName" />
+        <FieldConfigurer field="lastName" />
+        <FieldConfigurer field="age" />
+        <FieldConfigurer field="signUpDate" />
+      </>
+    )}
+    TemplateWrapper="ul"
+    ItemWrapper={({children}) => (
+      <li>
+        <ul>{children}</ul>
+      </li>
+    )}
+    FieldWrapper="li"
+  />
+);

--- a/src/templates/array-template/array-template.stories.tsx
+++ b/src/templates/array-template/array-template.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {makeComplexPeople, makeSimplePeople} from '../../mocks';
+import {makeComplexPeople, makeSimplePeople, SimplePerson} from '../../mocks';
 
 import {ArrayTemplate} from './array-template';
 import {FieldWrapper, ItemWrapper, Wrapper} from './support';
@@ -138,5 +138,37 @@ export const rawHtmlWrappers = () => (
       </li>
     )}
     FieldWrapper="li"
+  />
+);
+
+export const nullData = () => (
+  <ArrayTemplate<SimplePerson>
+    idField="id"
+    data={null}
+    configure={({FieldConfigurer}) => (
+      <>
+        <FieldConfigurer field="firstName" />
+        <FieldConfigurer field="lastName" />
+        <FieldConfigurer field="age" />
+        <FieldConfigurer field="signUpDate" />
+      </>
+    )}
+    noDataSlot={<>No data received</>}
+  />
+);
+
+export const emptyData = () => (
+  <ArrayTemplate<SimplePerson>
+    idField="id"
+    data={[]}
+    configure={({FieldConfigurer}) => (
+      <>
+        <FieldConfigurer field="firstName" />
+        <FieldConfigurer field="lastName" />
+        <FieldConfigurer field="age" />
+        <FieldConfigurer field="signUpDate" />
+      </>
+    )}
+    noDataSlot={<>No data received</>}
   />
 );

--- a/src/templates/array-template/array-template.stories.tsx
+++ b/src/templates/array-template/array-template.stories.tsx
@@ -172,3 +172,26 @@ export const emptyData = () => (
     noDataSlot={<>No data received</>}
   />
 );
+
+export const customFieldWrapper = () => (
+  <ArrayTemplate
+    idField="id"
+    data={makeSimplePeople(5)}
+    configure={({FieldConfigurer}) => (
+      <>
+        <FieldConfigurer
+          field="firstName"
+          wrapper={({children}) => (
+            <div style={{textTransform: 'uppercase'}}>{children}</div>
+          )}
+        />
+        <FieldConfigurer field="lastName" />
+        <FieldConfigurer field="age" />
+        <FieldConfigurer field="signUpDate" />
+      </>
+    )}
+    ItemWrapper={ItemWrapper}
+    TemplateWrapper={Wrapper}
+    FieldWrapper={FieldWrapper}
+  />
+);

--- a/src/templates/array-template/array-template.tsx
+++ b/src/templates/array-template/array-template.tsx
@@ -7,7 +7,7 @@ import {
   ItemWrapperType,
   TemplateWrapperType,
 } from '../support';
-import {DefaultWrapper, RenderItem} from '../common';
+import {DefaultWrapper, RenderItem, RenderTemplate} from '../common';
 
 export interface ArrayTemplateProps<
   T extends object,
@@ -36,8 +36,9 @@ export const UnboundArrayTemplate = <T extends object>({
   if (!data) {
     return null;
   }
+
   return (
-    <TemplateWrapper data={data}>
+    <RenderTemplate data={data} TemplateWrapper={TemplateWrapper}>
       {data.map((item) => {
         if (!item) {
           return null;
@@ -51,7 +52,7 @@ export const UnboundArrayTemplate = <T extends object>({
           />
         );
       })}
-    </TemplateWrapper>
+    </RenderTemplate>
   );
 };
 

--- a/src/templates/array-template/array-template.tsx
+++ b/src/templates/array-template/array-template.tsx
@@ -19,22 +19,21 @@ export interface ArrayTemplateProps<
   TemplateWrapper?: TemplateWrapperType<Maybe<T>[]>;
   ItemWrapper?: ItemWrapperType<T>;
   FieldWrapper?: FieldWrapperType<T>;
+  noDataSlot?: React.ReactElement;
 }
 
 export const ArrayTemplate = <T extends object>({
   data,
   configure: Configure,
   idField,
+  noDataSlot,
   TemplateWrapper = DefaultWrapper,
   ItemWrapper = DefaultWrapper,
   FieldWrapper = DefaultWrapper,
-}: ArrayTemplateProps<T>) => {
-  if (!data) {
-    return null;
-  }
-  return (
-    <FieldConfigurationProvider>
-      {Configure && <Configure FieldConfigurer={Configurer} />}
+}: ArrayTemplateProps<T>) => (
+  <FieldConfigurationProvider>
+    {Configure && <Configure FieldConfigurer={Configurer} />}
+    {data?.length ? (
       <RenderTemplate data={data} TemplateWrapper={TemplateWrapper}>
         {data.map((item) => {
           if (!item) {
@@ -50,6 +49,8 @@ export const ArrayTemplate = <T extends object>({
           );
         })}
       </RenderTemplate>
-    </FieldConfigurationProvider>
-  );
-};
+    ) : (
+      noDataSlot
+    )}
+  </FieldConfigurationProvider>
+);

--- a/src/templates/array-template/array-template.tsx
+++ b/src/templates/array-template/array-template.tsx
@@ -13,7 +13,7 @@ import {
   ItemWrapperType,
   TemplateWrapperType,
 } from '../support';
-import {DefaultWrapper} from '../common';
+import {DefaultWrapper, RenderField} from '../common';
 
 export interface ArrayTemplateProps<
   T extends object,
@@ -26,38 +26,6 @@ export interface ArrayTemplateProps<
   ItemWrapper?: ItemWrapperType<T>;
   FieldWrapper?: FieldWrapperType<T>;
 }
-
-type WrapFieldProps<T extends object> = Omit<
-  UnboundArrayTemplateProps<T>,
-  'TemplateWrapper' | 'ItemWrapper'
-> & {
-  data: Maybe<T>[];
-  datum: T;
-  fieldId: string;
-};
-
-const WrapField = <T extends object>({
-  datum,
-  fieldId,
-  FieldWrapper = DefaultWrapper,
-  ...rest
-}: WrapFieldProps<T>) => {
-  const {renderer: Renderer, ...config} = useFieldConfiguration(fieldId);
-  const value = _.get(datum, config.keyPath);
-  return (
-    <FieldWrapper
-      fieldId={fieldId}
-      value={value}
-      field={config.keyPath as IdType<T>}
-      renderer={Renderer}
-      {...rest}
-      {...config}
-      item={datum}
-    >
-      <Renderer value={value} />
-    </FieldWrapper>
-  );
-};
 
 export type UnboundArrayTemplateProps<T extends object> = Omit<
   ArrayTemplateProps<T>,
@@ -83,11 +51,9 @@ export const UnboundArrayTemplate = <T extends object>({
         }
 
         const children = fieldIds.map((fieldId) => (
-          <WrapField
-            idField={idField}
+          <RenderField
             key={fieldId}
-            data={data}
-            datum={datum}
+            item={datum}
             fieldId={fieldId}
             FieldWrapper={FieldWrapper}
           />

--- a/src/templates/array-template/array-template.tsx
+++ b/src/templates/array-template/array-template.tsx
@@ -1,19 +1,13 @@
-import _ from 'lodash';
 import React from 'react';
 
 import {ConfigureFunction, IdType, Maybe} from '../..';
-import {
-  Configurer,
-  FieldConfigurationProvider,
-  useConfiguredFieldIds,
-  useFieldConfiguration,
-} from '../configuration';
+import {Configurer, FieldConfigurationProvider} from '../configuration';
 import {
   FieldWrapperType,
   ItemWrapperType,
   TemplateWrapperType,
 } from '../support';
-import {DefaultWrapper, RenderField} from '../common';
+import {DefaultWrapper, RenderItem} from '../common';
 
 export interface ArrayTemplateProps<
   T extends object,
@@ -37,36 +31,24 @@ export const UnboundArrayTemplate = <T extends object>({
   idField,
   TemplateWrapper = DefaultWrapper,
   ItemWrapper = DefaultWrapper,
-  FieldWrapper,
+  FieldWrapper = DefaultWrapper,
 }: UnboundArrayTemplateProps<T>) => {
-  const fieldIds = useConfiguredFieldIds<T>();
   if (!data) {
     return null;
   }
   return (
     <TemplateWrapper data={data}>
-      {data.map((datum) => {
-        if (!datum) {
+      {data.map((item) => {
+        if (!item) {
           return null;
         }
-
-        const children = fieldIds.map((fieldId) => (
-          <RenderField
-            key={fieldId}
-            item={datum}
-            fieldId={fieldId}
+        return (
+          <RenderItem
+            key={String(item[idField])}
+            item={item}
+            ItemWrapper={ItemWrapper}
             FieldWrapper={FieldWrapper}
           />
-        ));
-        if (typeof ItemWrapper === 'string') {
-          const Tag = ItemWrapper as keyof JSX.IntrinsicElements;
-          return <Tag key={String(datum[idField])}>{children}</Tag>;
-        }
-
-        return (
-          <ItemWrapper key={String(datum[idField])} item={datum}>
-            {children}
-          </ItemWrapper>
         );
       })}
     </TemplateWrapper>

--- a/src/templates/array-template/array-template.tsx
+++ b/src/templates/array-template/array-template.tsx
@@ -41,17 +41,20 @@ const WrapField = <T extends object>({
   FieldWrapper,
   ...rest
 }: WrapFieldProps<T>) => {
-  const config = useFieldConfiguration(fieldId);
+  const {renderer: Renderer, ...config} = useFieldConfiguration(fieldId);
   const value = _.get(datum, config.keyPath);
   return (
     <FieldWrapper
       fieldId={fieldId}
       value={value}
       field={config.keyPath as IdType<T>}
+      renderer={Renderer}
       {...rest}
       {...config}
       data={datum}
-    />
+    >
+      <Renderer value={value} />
+    </FieldWrapper>
   );
 };
 

--- a/src/templates/array-template/array-template.tsx
+++ b/src/templates/array-template/array-template.tsx
@@ -15,7 +15,7 @@ export interface ArrayTemplateProps<
 > {
   data: Maybe<Maybe<T>[]>;
   idField: K;
-  configure: ConfigureFunction<T>;
+  configure?: ConfigureFunction<T>;
   TemplateWrapper?: TemplateWrapperType<Maybe<T>[]>;
   ItemWrapper?: ItemWrapperType<T>;
   FieldWrapper?: FieldWrapperType<T>;
@@ -34,7 +34,7 @@ export const ArrayTemplate = <T extends object>({
   }
   return (
     <FieldConfigurationProvider>
-      <Configure FieldConfigurer={Configurer} />
+      {Configure && <Configure FieldConfigurer={Configurer} />}
       <RenderTemplate data={data} TemplateWrapper={TemplateWrapper}>
         {data.map((item) => {
           if (!item) {

--- a/src/templates/array-template/array-template.tsx
+++ b/src/templates/array-template/array-template.tsx
@@ -21,47 +21,35 @@ export interface ArrayTemplateProps<
   FieldWrapper?: FieldWrapperType<T>;
 }
 
-export type UnboundArrayTemplateProps<T extends object> = Omit<
-  ArrayTemplateProps<T>,
-  'configure'
->;
-
-export const UnboundArrayTemplate = <T extends object>({
+export const ArrayTemplate = <T extends object>({
   data,
+  configure: Configure,
   idField,
   TemplateWrapper = DefaultWrapper,
   ItemWrapper = DefaultWrapper,
   FieldWrapper = DefaultWrapper,
-}: UnboundArrayTemplateProps<T>) => {
+}: ArrayTemplateProps<T>) => {
   if (!data) {
     return null;
   }
-
   return (
-    <RenderTemplate data={data} TemplateWrapper={TemplateWrapper}>
-      {data.map((item) => {
-        if (!item) {
-          return null;
-        }
-        return (
-          <RenderItem
-            key={String(item[idField])}
-            item={item}
-            ItemWrapper={ItemWrapper}
-            FieldWrapper={FieldWrapper}
-          />
-        );
-      })}
-    </RenderTemplate>
+    <FieldConfigurationProvider>
+      <Configure FieldConfigurer={Configurer} />
+      <RenderTemplate data={data} TemplateWrapper={TemplateWrapper}>
+        {data.map((item) => {
+          if (!item) {
+            return null;
+          }
+          return (
+            <RenderItem
+              key={String(item[idField])}
+              item={item}
+              ItemWrapper={ItemWrapper}
+              FieldWrapper={FieldWrapper}
+            />
+          );
+        })}
+      </RenderTemplate>
+    </FieldConfigurationProvider>
   );
 };
-
-export const ArrayTemplate = <T extends object>({
-  configure: Configure,
-  ...rest
-}: ArrayTemplateProps<T>) => (
-  <FieldConfigurationProvider>
-    <Configure FieldConfigurer={Configurer} />
-    <UnboundArrayTemplate {...rest} />
-  </FieldConfigurationProvider>
-);

--- a/src/templates/array-template/array-template.tsx
+++ b/src/templates/array-template/array-template.tsx
@@ -52,7 +52,7 @@ const WrapField = <T extends object>({
       renderer={Renderer}
       {...rest}
       {...config}
-      data={datum}
+      item={datum}
     >
       <Renderer value={value} />
     </FieldWrapper>
@@ -98,7 +98,7 @@ export const UnboundArrayTemplate = <T extends object>({
         }
 
         return (
-          <ItemWrapper key={String(datum[idField])} data={datum}>
+          <ItemWrapper key={String(datum[idField])} item={datum}>
             {children}
           </ItemWrapper>
         );

--- a/src/templates/array-template/array-template.tsx
+++ b/src/templates/array-template/array-template.tsx
@@ -9,9 +9,9 @@ import {
   useFieldConfiguration,
 } from '../configuration';
 import {
-  FieldWrapper as FieldWrapperType,
-  ItemWrapper as ItemWrapperType,
-  Wrapper as WrapperType,
+  FieldWrapperType,
+  ItemWrapperType,
+  TemplateWrapperType,
 } from '../support';
 
 export interface ArrayTemplateProps<
@@ -21,14 +21,14 @@ export interface ArrayTemplateProps<
   data: Maybe<Maybe<T>[]>;
   idField: K;
   configure: ConfigureFunction<T>;
-  Wrapper: WrapperType<Maybe<T>[]>;
+  TemplateWrapper: TemplateWrapperType<Maybe<T>[]>;
   ItemWrapper: ItemWrapperType<T>;
   FieldWrapper: FieldWrapperType<T>;
 }
 
 type WrapFieldProps<T extends object> = Omit<
   UnboundArrayTemplateProps<T>,
-  'Wrapper' | 'ItemWrapper'
+  'TemplateWrapper' | 'ItemWrapper'
 > & {
   data: Maybe<T>[];
   datum: T;
@@ -63,7 +63,7 @@ export type UnboundArrayTemplateProps<T extends object> = Omit<
 export const UnboundArrayTemplate = <T extends object>({
   data,
   idField,
-  Wrapper,
+  TemplateWrapper,
   ItemWrapper,
   FieldWrapper,
 }: UnboundArrayTemplateProps<T>) => {
@@ -72,7 +72,7 @@ export const UnboundArrayTemplate = <T extends object>({
     return null;
   }
   return (
-    <Wrapper data={data}>
+    <TemplateWrapper data={data}>
       {data.map((datum) => {
         if (!datum) {
           return null;
@@ -99,7 +99,7 @@ export const UnboundArrayTemplate = <T extends object>({
           </ItemWrapper>
         );
       })}
-    </Wrapper>
+    </TemplateWrapper>
   );
 };
 

--- a/src/templates/array-template/array-template.tsx
+++ b/src/templates/array-template/array-template.tsx
@@ -13,6 +13,7 @@ import {
   ItemWrapperType,
   TemplateWrapperType,
 } from '../support';
+import {DefaultWrapper} from '../common';
 
 export interface ArrayTemplateProps<
   T extends object,
@@ -21,9 +22,9 @@ export interface ArrayTemplateProps<
   data: Maybe<Maybe<T>[]>;
   idField: K;
   configure: ConfigureFunction<T>;
-  TemplateWrapper: TemplateWrapperType<Maybe<T>[]>;
-  ItemWrapper: ItemWrapperType<T>;
-  FieldWrapper: FieldWrapperType<T>;
+  TemplateWrapper?: TemplateWrapperType<Maybe<T>[]>;
+  ItemWrapper?: ItemWrapperType<T>;
+  FieldWrapper?: FieldWrapperType<T>;
 }
 
 type WrapFieldProps<T extends object> = Omit<
@@ -38,7 +39,7 @@ type WrapFieldProps<T extends object> = Omit<
 const WrapField = <T extends object>({
   datum,
   fieldId,
-  FieldWrapper,
+  FieldWrapper = DefaultWrapper,
   ...rest
 }: WrapFieldProps<T>) => {
   const {renderer: Renderer, ...config} = useFieldConfiguration(fieldId);
@@ -66,8 +67,8 @@ export type UnboundArrayTemplateProps<T extends object> = Omit<
 export const UnboundArrayTemplate = <T extends object>({
   data,
   idField,
-  TemplateWrapper,
-  ItemWrapper,
+  TemplateWrapper = DefaultWrapper,
+  ItemWrapper = DefaultWrapper,
   FieldWrapper,
 }: UnboundArrayTemplateProps<T>) => {
   const fieldIds = useConfiguredFieldIds<T>();

--- a/src/templates/array-template/support.tsx
+++ b/src/templates/array-template/support.tsx
@@ -22,14 +22,13 @@ export const Wrapper = <T extends unknown>({
 
 export const FieldWrapper = <T extends object, K extends IdType<T>>({
   fieldId,
-  value,
-  renderer: Renderer,
+  children,
 }: FieldWrapperProps<T, K>) => {
   const {label} = useFieldConfiguration(fieldId);
 
   return (
     <li>
-      {label}: <Renderer value={value} />
+      {label}: {children}
     </li>
   );
 };

--- a/src/templates/array-template/support.tsx
+++ b/src/templates/array-template/support.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 
 import {IdType, Maybe} from '../..';
 import {useFieldConfiguration} from '../configuration';
-import {FieldWrapperProps, ItemWrapperProps, WrapperProps} from '../support';
+import {
+  FieldWrapperProps,
+  ItemWrapperProps,
+  TemplateWrapperProps,
+} from '../support';
 
 export const ItemWrapper = <T extends object>({
   children,
@@ -14,7 +18,7 @@ export const ItemWrapper = <T extends object>({
 
 export const Wrapper = <T extends unknown>({
   children,
-}: WrapperProps<Maybe<T[]>>) => <ul>{children}</ul>;
+}: TemplateWrapperProps<Maybe<T[]>>) => <ul>{children}</ul>;
 
 export const FieldWrapper = <T extends object, K extends IdType<T>>({
   fieldId,

--- a/src/templates/common.tsx
+++ b/src/templates/common.tsx
@@ -3,7 +3,11 @@ import _ from 'lodash';
 
 import {IdType} from '../types';
 
-import {FieldWrapperType, ItemWrapperType} from './support';
+import {
+  FieldWrapperType,
+  ItemWrapperType,
+  TemplateWrapperType,
+} from './support';
 import {useConfiguredFieldIds, useFieldConfiguration} from './configuration';
 
 export const DefaultWrapper = <T extends object>({
@@ -72,4 +76,33 @@ export const RenderItem = <T extends object>({
   }
 
   return <ItemWrapper item={item}>{children}</ItemWrapper>;
+};
+
+export interface RenderTemplateProps<T extends unknown> {
+  /**
+   * Unlike the other Wrapper render components, the TemplateWrapper needs to
+   * have different behavior depending on if T is an object or array. That logic
+   * is handled in ArrayTemplate or ObjectTemplate and passed to RenderTemplate
+   * as `children`.
+   */
+  children: React.ReactNode;
+  data: T;
+  TemplateWrapper?: TemplateWrapperType<T>;
+}
+
+// I'd rather this was just <T>, but that doesn't work in jsx/tsx files.
+export const RenderTemplate = <T extends unknown>({
+  children,
+  data,
+  TemplateWrapper = DefaultWrapper,
+}: RenderTemplateProps<T>) => {
+  if (typeof TemplateWrapper === 'string') {
+    // It's not clear to me why tsc sees an error with TemplateWrapper here. As
+    // far as I can tell, everything is typed identically to RenderItem and
+    // RenderField.
+    // @ts-expect-error
+    return <TemplateWrapper>{children}</TemplateWrapper>;
+  }
+
+  return <TemplateWrapper data={data}>{children}</TemplateWrapper>;
 };

--- a/src/templates/common.tsx
+++ b/src/templates/common.tsx
@@ -1,0 +1,5 @@
+import React, {PropsWithChildren} from 'react';
+
+export const DefaultWrapper = <T extends object>({
+  children,
+}: PropsWithChildren<T>) => <>{children}</>;

--- a/src/templates/common.tsx
+++ b/src/templates/common.tsx
@@ -1,5 +1,46 @@
 import React, {PropsWithChildren} from 'react';
+import _ from 'lodash';
+
+import {IdType} from '../types';
+
+import {FieldWrapperType} from './support';
+import {useFieldConfiguration} from './configuration';
 
 export const DefaultWrapper = <T extends object>({
   children,
 }: PropsWithChildren<T>) => <>{children}</>;
+
+export interface RenderFieldProps<T extends object> {
+  fieldId: string;
+  FieldWrapper?: FieldWrapperType<T>;
+  item: T;
+}
+
+export const RenderField = <T extends object>({
+  fieldId,
+  FieldWrapper = DefaultWrapper,
+  item,
+}: RenderFieldProps<T>) => {
+  const {renderer: Renderer, ...config} = useFieldConfiguration(fieldId);
+  const value = _.get(item, config.keyPath);
+  if (typeof FieldWrapper === 'string') {
+    return (
+      <FieldWrapper>
+        <Renderer value={value} />
+      </FieldWrapper>
+    );
+  }
+
+  return (
+    <FieldWrapper
+      fieldId={fieldId}
+      field={config.keyPath as IdType<T>}
+      item={item}
+      renderer={Renderer}
+      value={value}
+      {...config}
+    >
+      <Renderer value={value} />
+    </FieldWrapper>
+  );
+};

--- a/src/templates/common.tsx
+++ b/src/templates/common.tsx
@@ -3,8 +3,8 @@ import _ from 'lodash';
 
 import {IdType} from '../types';
 
-import {FieldWrapperType} from './support';
-import {useFieldConfiguration} from './configuration';
+import {FieldWrapperType, ItemWrapperType} from './support';
+import {useConfiguredFieldIds, useFieldConfiguration} from './configuration';
 
 export const DefaultWrapper = <T extends object>({
   children,
@@ -43,4 +43,33 @@ export const RenderField = <T extends object>({
       <Renderer value={value} />
     </FieldWrapper>
   );
+};
+
+export interface RenderItemProps<T extends object> {
+  item: T;
+  ItemWrapper?: ItemWrapperType<T>;
+  FieldWrapper?: FieldWrapperType<T>;
+}
+
+export const RenderItem = <T extends object>({
+  item,
+  ItemWrapper = DefaultWrapper,
+  FieldWrapper = DefaultWrapper,
+}: RenderItemProps<T>) => {
+  const fieldIds = useConfiguredFieldIds<T>();
+
+  const children = fieldIds.map((fieldId) => (
+    <RenderField
+      key={fieldId}
+      item={item}
+      fieldId={fieldId}
+      FieldWrapper={FieldWrapper}
+    />
+  ));
+
+  if (typeof ItemWrapper === 'string') {
+    return <ItemWrapper>{children}</ItemWrapper>;
+  }
+
+  return <ItemWrapper item={item}>{children}</ItemWrapper>;
 };

--- a/src/templates/common.tsx
+++ b/src/templates/common.tsx
@@ -25,18 +25,24 @@ export const RenderField = <T extends object>({
   FieldWrapper = DefaultWrapper,
   item,
 }: RenderFieldProps<T>) => {
-  const {renderer: Renderer, ...config} = useFieldConfiguration(fieldId);
+  const {
+    renderer: Renderer,
+    wrapper,
+    ...config
+  } = useFieldConfiguration(fieldId);
   const value = _.get(item, config.keyPath);
-  if (typeof FieldWrapper === 'string') {
+
+  const Wrapper = wrapper || FieldWrapper;
+  if (typeof Wrapper === 'string') {
     return (
-      <FieldWrapper>
+      <Wrapper>
         <Renderer value={value} />
-      </FieldWrapper>
+      </Wrapper>
     );
   }
 
   return (
-    <FieldWrapper
+    <Wrapper
       fieldId={fieldId}
       field={config.keyPath as IdType<T>}
       item={item}
@@ -45,7 +51,7 @@ export const RenderField = <T extends object>({
       {...config}
     >
       <Renderer value={value} />
-    </FieldWrapper>
+    </Wrapper>
   );
 };
 

--- a/src/templates/configuration/configuration.tsx
+++ b/src/templates/configuration/configuration.tsx
@@ -1,13 +1,14 @@
 import {startCase} from 'lodash';
 import React, {useContext} from 'react';
 
-import {AnyRenderer} from '../..';
+import {AnyRenderer, FieldWrapperType} from '../..';
 import {Renderer} from '../../renderers';
 
 export type FieldConfiguration = {
   label: React.ReactNode;
   keyPath: string;
   renderer: Renderer;
+  wrapper?: FieldWrapperType<object>;
 };
 
 export type FieldConfigurationWithDefaults = Partial<FieldConfiguration>;

--- a/src/templates/configuration/configuration.tsx
+++ b/src/templates/configuration/configuration.tsx
@@ -2,7 +2,7 @@ import {startCase} from 'lodash';
 import React, {useContext} from 'react';
 
 import {AnyRenderer} from '../..';
-import {Renderer} from '../../support';
+import {Renderer} from '../../renderers';
 
 export type FieldConfiguration = {
   label: React.ReactNode;

--- a/src/templates/configuration/configurer.tsx
+++ b/src/templates/configuration/configurer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import {Renderer} from '../../support';
 import {Definitely, IdType, Maybe} from '../..';
+import {Renderer} from '../../renderers/types';
 
 import {FieldConfigurationProvider} from './configuration';
 import {useConfigureField} from './hooks';

--- a/src/templates/configuration/configurer.tsx
+++ b/src/templates/configuration/configurer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import {Definitely, IdType, Maybe} from '../..';
-import {Renderer} from '../../renderers/types';
+import {Definitely, FieldWrapperProps, IdType, Maybe} from '../..';
+import {Renderer} from '../../renderers';
 
 import {FieldConfigurationProvider} from './configuration';
 import {useConfigureField} from './hooks';
@@ -20,6 +20,7 @@ export interface ConfigurerProps<T extends object, K extends IdType<T>> {
   field: K;
   label?: React.ReactNode | Renderer<K>;
   renderer?: Renderer<T[K]>;
+  wrapper?: React.ElementType<FieldWrapperProps<T, K>>;
   configure?: T[K] extends Maybe<object>
     ? React.ElementType<ConfigureFunctionProps<Definitely<T[K]>>>
     : never;

--- a/src/templates/connection-template/__snapshots__/connection-template.stories.storyshot
+++ b/src/templates/connection-template/__snapshots__/connection-template.stories.storyshot
@@ -150,6 +150,56 @@ exports[`Storyshots Templates/ConnectionTemplate Connection Template 1`] = `
 </ul>
 `;
 
+exports[`Storyshots Templates/ConnectionTemplate Default No Op 1`] = `
+Array [
+  "Joshua",
+  "Jenkins",
+  "9",
+  <time
+    dateTime={"2019-04-21T09:24:38.262Z"}
+    title="2019-04-21T09:24:38+00:00"
+  >
+    April 21, 2019
+  </time>,
+  "Lennie",
+  "Krajcik",
+  "69",
+  <time
+    dateTime={"2020-05-21T20:24:48.713Z"}
+    title="2020-05-21T20:24:48+00:00"
+  >
+    May 21, 2020
+  </time>,
+  "Ophelia",
+  "Olson",
+  "92",
+  <time
+    dateTime={"2019-03-05T01:04:28.401Z"}
+    title="2019-03-05T01:04:28+00:00"
+  >
+    March 5, 2019
+  </time>,
+  "Annabelle",
+  "Hamill",
+  "31",
+  <time
+    dateTime={"2020-10-04T14:50:38.937Z"}
+    title="2020-10-04T14:50:38+00:00"
+  >
+    October 4, 2020
+  </time>,
+  "Foster",
+  "Runolfsson",
+  "83",
+  <time
+    dateTime={"2020-09-30T22:08:33.801Z"}
+    title="2020-09-30T22:08:33+00:00"
+  >
+    September 30, 2020
+  </time>,
+]
+`;
+
 exports[`Storyshots Templates/ConnectionTemplate Duplicate Fields 1`] = `
 <ul>
   <li>

--- a/src/templates/connection-template/connection-template.spec.tsx
+++ b/src/templates/connection-template/connection-template.spec.tsx
@@ -27,7 +27,7 @@ describe('ConnectionTemplate', () => {
           </>
         )}
         ItemWrapper={ItemWrapper}
-        Wrapper={Wrapper}
+        TemplateWrapper={Wrapper}
         FieldWrapper={FieldWrapper}
       />
     );
@@ -58,7 +58,7 @@ describe('ConnectionTemplate', () => {
           </>
         )}
         ItemWrapper={ItemWrapper}
-        Wrapper={Wrapper}
+        TemplateWrapper={Wrapper}
         FieldWrapper={FieldWrapper}
       />
     );
@@ -91,7 +91,7 @@ describe('ConnectionTemplate', () => {
           </>
         )}
         ItemWrapper={ItemWrapper}
-        Wrapper={Wrapper}
+        TemplateWrapper={Wrapper}
         FieldWrapper={FieldWrapper}
       />
     );
@@ -127,7 +127,7 @@ describe('ConnectionTemplate', () => {
           </>
         )}
         ItemWrapper={ItemWrapper}
-        Wrapper={Wrapper}
+        TemplateWrapper={Wrapper}
         FieldWrapper={FieldWrapper}
       />
     );
@@ -148,7 +148,7 @@ describe('ConnectionTemplate', () => {
           </>
         )}
         ItemWrapper={ItemWrapper}
-        Wrapper={Wrapper}
+        TemplateWrapper={Wrapper}
         FieldWrapper={FieldWrapper}
       />
     );

--- a/src/templates/connection-template/connection-template.stories.tsx
+++ b/src/templates/connection-template/connection-template.stories.tsx
@@ -22,7 +22,7 @@ export const connectionTemplate = () => (
       </>
     )}
     ItemWrapper={ItemWrapper}
-    Wrapper={Wrapper}
+    TemplateWrapper={Wrapper}
     FieldWrapper={FieldWrapper}
   />
 );
@@ -39,7 +39,7 @@ export const outOfOrder = () => (
       </>
     )}
     ItemWrapper={ItemWrapper}
-    Wrapper={Wrapper}
+    TemplateWrapper={Wrapper}
     FieldWrapper={FieldWrapper}
   />
 );
@@ -63,7 +63,7 @@ export const duplicateFields = () => (
       </>
     )}
     ItemWrapper={ItemWrapper}
-    Wrapper={Wrapper}
+    TemplateWrapper={Wrapper}
     FieldWrapper={FieldWrapper}
   />
 );
@@ -87,7 +87,7 @@ export const nestedData = () => (
       </>
     )}
     ItemWrapper={ItemWrapper}
-    Wrapper={Wrapper}
+    TemplateWrapper={Wrapper}
     FieldWrapper={FieldWrapper}
   />
 );

--- a/src/templates/connection-template/connection-template.stories.tsx
+++ b/src/templates/connection-template/connection-template.stories.tsx
@@ -91,3 +91,25 @@ export const nestedData = () => (
     FieldWrapper={FieldWrapper}
   />
 );
+
+export const defaultNoOp = () => (
+  <ConnectionTemplate
+    connection={toConnection(makeSimplePeople(5))}
+    configure={({FieldConfigurer}) => (
+      <>
+        <FieldConfigurer field="firstName" />
+        <FieldConfigurer field="lastName" />
+        <FieldConfigurer field="age" />
+        <FieldConfigurer field="signUpDate" />
+      </>
+    )}
+  />
+);
+defaultNoOp.parameters = {
+  docs: {
+    description: {
+      story:
+        "If Wrappers are not provided, the Template will still render _something_. It almost certainly won't be pretty, but after using Templates in the wild, it became clear that a lost of specialization might not need full customizations, so adding noop-rendering makes a lot of implementations much easier.",
+    },
+  },
+};

--- a/src/templates/connection-template/connection-template.tsx
+++ b/src/templates/connection-template/connection-template.tsx
@@ -15,6 +15,7 @@ export interface ConnectionTemplateProps<N extends NodeLike, PI> {
   TemplateWrapper?: TemplateWrapperType<Maybe<N>[]>;
   ItemWrapper?: ItemWrapperType<N>;
   FieldWrapper?: FieldWrapperType<N>;
+  noDataSlot?: React.ReactElement;
 }
 
 export const ConnectionTemplate = <N extends NodeLike, PI>({

--- a/src/templates/connection-template/connection-template.tsx
+++ b/src/templates/connection-template/connection-template.tsx
@@ -8,15 +8,15 @@ import {
 } from '../configuration';
 import {UnboundArrayTemplate} from '../array-template';
 import {
-  FieldWrapper as FieldWrapperType,
-  ItemWrapper as ItemWrapperType,
-  Wrapper as WrapperType,
+  FieldWrapperType,
+  ItemWrapperType,
+  TemplateWrapperType,
 } from '../support';
 
 export interface ConnectionTemplateProps<N extends NodeLike, PI> {
   connection: Maybe<ConnectionLike<N, PI>>;
   configure: ConfigureFunction<N>;
-  Wrapper: WrapperType<Maybe<N>[]>;
+  TemplateWrapper: TemplateWrapperType<Maybe<N>[]>;
   ItemWrapper: ItemWrapperType<N>;
   FieldWrapper: FieldWrapperType<N>;
 }

--- a/src/templates/connection-template/connection-template.tsx
+++ b/src/templates/connection-template/connection-template.tsx
@@ -16,9 +16,9 @@ import {
 export interface ConnectionTemplateProps<N extends NodeLike, PI> {
   connection: Maybe<ConnectionLike<N, PI>>;
   configure: ConfigureFunction<N>;
-  TemplateWrapper: TemplateWrapperType<Maybe<N>[]>;
-  ItemWrapper: ItemWrapperType<N>;
-  FieldWrapper: FieldWrapperType<N>;
+  TemplateWrapper?: TemplateWrapperType<Maybe<N>[]>;
+  ItemWrapper?: ItemWrapperType<N>;
+  FieldWrapper?: FieldWrapperType<N>;
 }
 
 export type UnboundConnectionTemplateProps<N extends NodeLike, PI> = Omit<

--- a/src/templates/connection-template/connection-template.tsx
+++ b/src/templates/connection-template/connection-template.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
 
 import {ConnectionLike, IdType, Maybe, NodeLike, useEdgeNodes} from '../..';
-import {
-  ConfigureFunction,
-  Configurer,
-  FieldConfigurationProvider,
-} from '../configuration';
-import {UnboundArrayTemplate} from '../array-template';
+import {ConfigureFunction} from '../configuration';
+import {ArrayTemplate} from '../array-template';
 import {
   FieldWrapperType,
   ItemWrapperType,
@@ -21,30 +17,15 @@ export interface ConnectionTemplateProps<N extends NodeLike, PI> {
   FieldWrapper?: FieldWrapperType<N>;
 }
 
-export type UnboundConnectionTemplateProps<N extends NodeLike, PI> = Omit<
-  ConnectionTemplateProps<N, PI>,
-  'configure'
->;
-
-export const UnboundConnectionTemplate = <N extends NodeLike, PI>({
+export const ConnectionTemplate = <N extends NodeLike, PI>({
   connection,
   ...rest
-}: UnboundConnectionTemplateProps<N, PI>) => {
+}: ConnectionTemplateProps<N, PI>) => {
   const nodes = useEdgeNodes(connection?.edges);
 
   // @ts-expect-error - tsc can't tell that "id" is a key of N rather than just
   // an arbitrary string. If I use NodeLike instead of N, it works.
   const idField: IdType<N> = 'id';
 
-  return <UnboundArrayTemplate idField={idField} data={nodes} {...rest} />;
+  return <ArrayTemplate idField={idField} data={nodes} {...rest} />;
 };
-
-export const ConnectionTemplate = <N extends NodeLike, PI>({
-  configure: Configure,
-  ...rest
-}: ConnectionTemplateProps<N, PI>) => (
-  <FieldConfigurationProvider>
-    <Configure FieldConfigurer={Configurer} />
-    <UnboundConnectionTemplate {...rest} />
-  </FieldConfigurationProvider>
-);

--- a/src/templates/connection-template/support.tsx
+++ b/src/templates/connection-template/support.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 
 import {IdType, Maybe, NodeLike} from '../..';
 import {useFieldConfiguration} from '../configuration';
-import {FieldWrapperProps, ItemWrapperProps, WrapperProps} from '../support';
+import {
+  FieldWrapperProps,
+  ItemWrapperProps,
+  TemplateWrapperProps,
+} from '../support';
 
 export const ItemWrapper = <T extends object>({
   children,
@@ -14,7 +18,7 @@ export const ItemWrapper = <T extends object>({
 
 export const Wrapper = <T extends unknown>({
   children,
-}: WrapperProps<Maybe<T[]>>) => <ul>{children}</ul>;
+}: TemplateWrapperProps<Maybe<T[]>>) => <ul>{children}</ul>;
 
 export const FieldWrapper = <T extends object, K extends IdType<T>>({
   fieldId,

--- a/src/templates/connection-template/support.tsx
+++ b/src/templates/connection-template/support.tsx
@@ -22,14 +22,13 @@ export const Wrapper = <T extends unknown>({
 
 export const FieldWrapper = <T extends object, K extends IdType<T>>({
   fieldId,
-  value,
-  renderer: Renderer,
+  children,
 }: FieldWrapperProps<T, K>) => {
   const {label} = useFieldConfiguration(fieldId);
 
   return (
     <li>
-      {label}: <Renderer value={value} />
+      {label}: {children}
     </li>
   );
 };

--- a/src/templates/object-template/__snapshots__/object-template.stories.storyshot
+++ b/src/templates/object-template/__snapshots__/object-template.stories.storyshot
@@ -235,21 +235,25 @@ exports[`Storyshots Templates/ObjectTemplate Out Of Order 1`] = `
 exports[`Storyshots Templates/ObjectTemplate Raw Html Wrappers 1`] = `
 <ul>
   <li>
-    Joshua
-  </li>
-  <li>
-    Jenkins
-  </li>
-  <li>
-    9
-  </li>
-  <li>
-    <time
-      dateTime={"2019-04-21T09:24:38.262Z"}
-      title="2019-04-21T09:24:38+00:00"
-    >
-      April 21, 2019
-    </time>
+    <ul>
+      <li>
+        Joshua
+      </li>
+      <li>
+        Jenkins
+      </li>
+      <li>
+        9
+      </li>
+      <li>
+        <time
+          dateTime={"2019-04-21T09:24:38.262Z"}
+          title="2019-04-21T09:24:38+00:00"
+        >
+          April 21, 2019
+        </time>
+      </li>
+    </ul>
   </li>
 </ul>
 `;

--- a/src/templates/object-template/__snapshots__/object-template.stories.storyshot
+++ b/src/templates/object-template/__snapshots__/object-template.stories.storyshot
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Templates/ObjectTemplate Default No Op 1`] = `
+Array [
+  "Joshua",
+  "Jenkins",
+  "9",
+  <time
+    dateTime={"2019-04-21T09:24:38.262Z"}
+    title="2019-04-21T09:24:38+00:00"
+  >
+    April 21, 2019
+  </time>,
+]
+`;
+
 exports[`Storyshots Templates/ObjectTemplate Duplicate Fields 1`] = `
 <dl
   className="description-list"

--- a/src/templates/object-template/__snapshots__/object-template.stories.storyshot
+++ b/src/templates/object-template/__snapshots__/object-template.stories.storyshot
@@ -231,3 +231,25 @@ exports[`Storyshots Templates/ObjectTemplate Out Of Order 1`] = `
   </dd>
 </dl>
 `;
+
+exports[`Storyshots Templates/ObjectTemplate Raw Html Wrappers 1`] = `
+<ul>
+  <li>
+    Joshua
+  </li>
+  <li>
+    Jenkins
+  </li>
+  <li>
+    9
+  </li>
+  <li>
+    <time
+      dateTime={"2019-04-21T09:24:38.262Z"}
+      title="2019-04-21T09:24:38+00:00"
+    >
+      April 21, 2019
+    </time>
+  </li>
+</ul>
+`;

--- a/src/templates/object-template/__snapshots__/object-template.stories.storyshot
+++ b/src/templates/object-template/__snapshots__/object-template.stories.storyshot
@@ -128,6 +128,8 @@ exports[`Storyshots Templates/ObjectTemplate Nested Data 1`] = `
 </dl>
 `;
 
+exports[`Storyshots Templates/ObjectTemplate Null Data 1`] = `"No data received"`;
+
 exports[`Storyshots Templates/ObjectTemplate Object Template 1`] = `
 <dl
   className="description-list"

--- a/src/templates/object-template/__snapshots__/object-template.stories.storyshot
+++ b/src/templates/object-template/__snapshots__/object-template.stories.storyshot
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Templates/ObjectTemplate Custom Field Wrapper 1`] = `
+Array [
+  <div
+    style={
+      Object {
+        "textTransform": "uppercase",
+      }
+    }
+  >
+    Joshua
+  </div>,
+  "Jenkins",
+  "9",
+  <time
+    dateTime={"2019-04-21T09:24:38.262Z"}
+    title="2019-04-21T09:24:38+00:00"
+  >
+    April 21, 2019
+  </time>,
+]
+`;
+
 exports[`Storyshots Templates/ObjectTemplate Default No Op 1`] = `
 Array [
   "Joshua",

--- a/src/templates/object-template/__snapshots__/object-template.stories.storyshot
+++ b/src/templates/object-template/__snapshots__/object-template.stories.storyshot
@@ -52,12 +52,12 @@ exports[`Storyshots Templates/ObjectTemplate Duplicate Fields 1`] = `
   <dt
     className="description-list__term description-list__term--single"
   >
-    Seconds since signup
+    Epoch Time
   </dt>
   <dd
     className="description-list__description description-list__description--single"
   >
-    53620521738
+    1555838678262
   </dd>
 </dl>
 `;

--- a/src/templates/object-template/object-template.spec.tsx
+++ b/src/templates/object-template/object-template.spec.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import {ComplexPerson, SimplePerson} from '../../mocks';
 import {InstallationPageQuery} from '../../sample-types';
 
-import {ItemWrapper, Wrapper} from './support';
+import {FieldWrapper, TemplateWrapper} from './support';
 
 import {ObjectTemplate} from '.';
 
@@ -26,8 +26,8 @@ describe('ObjectTemplate', () => {
             <FieldConfigurer field="invalid" />
           </>
         )}
-        FieldWrapper={ItemWrapper}
-        TemplateWrapper={Wrapper}
+        FieldWrapper={FieldWrapper}
+        TemplateWrapper={TemplateWrapper}
       />
     );
   });
@@ -56,8 +56,8 @@ describe('ObjectTemplate', () => {
             <FieldConfigurer field="invalid" />
           </>
         )}
-        FieldWrapper={ItemWrapper}
-        TemplateWrapper={Wrapper}
+        FieldWrapper={FieldWrapper}
+        TemplateWrapper={TemplateWrapper}
       />
     );
   });
@@ -77,8 +77,8 @@ describe('ObjectTemplate', () => {
             <FieldConfigurer field="invalid" />
           </>
         )}
-        FieldWrapper={ItemWrapper}
-        TemplateWrapper={Wrapper}
+        FieldWrapper={FieldWrapper}
+        TemplateWrapper={TemplateWrapper}
       />
     );
   });

--- a/src/templates/object-template/object-template.spec.tsx
+++ b/src/templates/object-template/object-template.spec.tsx
@@ -27,7 +27,7 @@ describe('ObjectTemplate', () => {
           </>
         )}
         FieldWrapper={ItemWrapper}
-        Wrapper={Wrapper}
+        TemplateWrapper={Wrapper}
       />
     );
   });
@@ -57,7 +57,7 @@ describe('ObjectTemplate', () => {
           </>
         )}
         FieldWrapper={ItemWrapper}
-        Wrapper={Wrapper}
+        TemplateWrapper={Wrapper}
       />
     );
   });
@@ -78,7 +78,7 @@ describe('ObjectTemplate', () => {
           </>
         )}
         FieldWrapper={ItemWrapper}
-        Wrapper={Wrapper}
+        TemplateWrapper={Wrapper}
       />
     );
   });

--- a/src/templates/object-template/object-template.stories.tsx
+++ b/src/templates/object-template/object-template.stories.tsx
@@ -159,3 +159,22 @@ export const nullData = () => (
     noDataSlot={<>No data received</>}
   />
 );
+
+export const customFieldWrapper = () => (
+  <ObjectTemplate<SimplePerson>
+    data={makeSimplePerson()}
+    configure={({FieldConfigurer}) => (
+      <>
+        <FieldConfigurer
+          field="firstName"
+          wrapper={({children}) => (
+            <div style={{textTransform: 'uppercase'}}>{children}</div>
+          )}
+        />
+        <FieldConfigurer field="lastName" />
+        <FieldConfigurer field="age" />
+        <FieldConfigurer field="signUpDate" />
+      </>
+    )}
+  />
+);

--- a/src/templates/object-template/object-template.stories.tsx
+++ b/src/templates/object-template/object-template.stories.tsx
@@ -115,3 +115,24 @@ defaultNoOp.parameters = {
     },
   },
 };
+
+export const rawHtmlWrappers = () => (
+  <ObjectTemplate
+    data={makeSimplePerson()}
+    configure={({FieldConfigurer}) => (
+      <>
+        <FieldConfigurer field="firstName" />
+        <FieldConfigurer field="lastName" />
+        <FieldConfigurer field="age" />
+        <FieldConfigurer field="signUpDate" />
+      </>
+    )}
+    TemplateWrapper="ul"
+    ItemWrapper={({children}) => (
+      <li>
+        <ul>{children}</ul>
+      </li>
+    )}
+    FieldWrapper="li"
+  />
+);

--- a/src/templates/object-template/object-template.stories.tsx
+++ b/src/templates/object-template/object-template.stories.tsx
@@ -64,6 +64,14 @@ export const duplicateFields = () => (
     TemplateWrapper={Wrapper}
   />
 );
+duplicateFields.parameters = {
+  docs: {
+    description: {
+      story:
+        'In this example, we configure the `signUpDate` property twice. First, we simply render it as a date, but then we configure it again and render as a Unix Epoch.',
+    },
+  },
+};
 
 export const nestedData = () => (
   <ObjectTemplate

--- a/src/templates/object-template/object-template.stories.tsx
+++ b/src/templates/object-template/object-template.stories.tsx
@@ -136,3 +136,11 @@ export const rawHtmlWrappers = () => (
     FieldWrapper="li"
   />
 );
+rawHtmlWrappers.parameters = {
+  docs: {
+    description: {
+      story:
+        "> Note that the ItemWrapper here is kinda silly; it's here primarily to confirm that it works. For real-world use of ObjectTemplates, you'd probably omit the `ItemWrapper` and just include the `TemplateWrapper` and `FieldWrapper`.",
+    },
+  },
+};

--- a/src/templates/object-template/object-template.stories.tsx
+++ b/src/templates/object-template/object-template.stories.tsx
@@ -93,3 +93,25 @@ export const nestedData = () => (
     TemplateWrapper={TemplateWrapper}
   />
 );
+
+export const defaultNoOp = () => (
+  <ObjectTemplate
+    data={makeSimplePerson()}
+    configure={({FieldConfigurer}) => (
+      <>
+        <FieldConfigurer field="firstName" />
+        <FieldConfigurer field="lastName" />
+        <FieldConfigurer field="age" />
+        <FieldConfigurer field="signUpDate" />
+      </>
+    )}
+  />
+);
+defaultNoOp.parameters = {
+  docs: {
+    description: {
+      story:
+        "If Wrappers are not provided, the Template will still render _something_. It almost certainly won't be pretty, but after using Templates in the wild, it became clear that a lost of specialization might not need full customizations, so adding noop-rendering makes a lot of implementations much easier.",
+    },
+  },
+};

--- a/src/templates/object-template/object-template.stories.tsx
+++ b/src/templates/object-template/object-template.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {makeComplexPerson, makeSimplePerson} from '../../mocks';
+import {makeComplexPerson, makeSimplePerson, SimplePerson} from '../../mocks';
 
 import {ObjectTemplate} from './object-template';
 import {FieldWrapper, TemplateWrapper} from './support';
@@ -144,3 +144,18 @@ rawHtmlWrappers.parameters = {
     },
   },
 };
+
+export const nullData = () => (
+  <ObjectTemplate<SimplePerson>
+    data={null}
+    configure={({FieldConfigurer}) => (
+      <>
+        <FieldConfigurer field="firstName" />
+        <FieldConfigurer field="lastName" />
+        <FieldConfigurer field="age" />
+        <FieldConfigurer field="signUpDate" />
+      </>
+    )}
+    noDataSlot={<>No data received</>}
+  />
+);

--- a/src/templates/object-template/object-template.stories.tsx
+++ b/src/templates/object-template/object-template.stories.tsx
@@ -22,7 +22,7 @@ export const objectTemplate = () => (
       </>
     )}
     FieldWrapper={ItemWrapper}
-    Wrapper={Wrapper}
+    TemplateWrapper={Wrapper}
   />
 );
 
@@ -38,7 +38,7 @@ export const outOfOrder = () => (
       </>
     )}
     FieldWrapper={ItemWrapper}
-    Wrapper={Wrapper}
+    TemplateWrapper={Wrapper}
   />
 );
 
@@ -61,7 +61,7 @@ export const duplicateFields = () => (
       </>
     )}
     FieldWrapper={ItemWrapper}
-    Wrapper={Wrapper}
+    TemplateWrapper={Wrapper}
   />
 );
 
@@ -84,6 +84,6 @@ export const nestedData = () => (
       </>
     )}
     FieldWrapper={ItemWrapper}
-    Wrapper={Wrapper}
+    TemplateWrapper={Wrapper}
   />
 );

--- a/src/templates/object-template/object-template.stories.tsx
+++ b/src/templates/object-template/object-template.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {makeComplexPerson, makeSimplePerson} from '../../mocks';
 
 import {ObjectTemplate} from './object-template';
-import {ItemWrapper, Wrapper} from './support';
+import {FieldWrapper, TemplateWrapper} from './support';
 
 export default {
   component: ObjectTemplate,
@@ -21,8 +21,8 @@ export const objectTemplate = () => (
         <FieldConfigurer field="signUpDate" />
       </>
     )}
-    FieldWrapper={ItemWrapper}
-    TemplateWrapper={Wrapper}
+    FieldWrapper={FieldWrapper}
+    TemplateWrapper={TemplateWrapper}
   />
 );
 
@@ -37,8 +37,8 @@ export const outOfOrder = () => (
         <FieldConfigurer field="age" />
       </>
     )}
-    FieldWrapper={ItemWrapper}
-    TemplateWrapper={Wrapper}
+    FieldWrapper={FieldWrapper}
+    TemplateWrapper={TemplateWrapper}
   />
 );
 
@@ -53,15 +53,13 @@ export const duplicateFields = () => (
         <FieldConfigurer field="signUpDate" />
         <FieldConfigurer
           field="signUpDate"
-          label="Seconds since signup"
-          renderer={({value}) => (
-            <>{Date.parse('2021-01-01') - value.getTime()}</>
-          )}
+          label="Epoch Time"
+          renderer={({value}) => <>{value.getTime()}</>}
         />
       </>
     )}
-    FieldWrapper={ItemWrapper}
-    TemplateWrapper={Wrapper}
+    FieldWrapper={FieldWrapper}
+    TemplateWrapper={TemplateWrapper}
   />
 );
 duplicateFields.parameters = {
@@ -91,7 +89,7 @@ export const nestedData = () => (
         <FieldConfigurer field="age" />
       </>
     )}
-    FieldWrapper={ItemWrapper}
-    TemplateWrapper={Wrapper}
+    FieldWrapper={FieldWrapper}
+    TemplateWrapper={TemplateWrapper}
   />
 );

--- a/src/templates/object-template/object-template.tsx
+++ b/src/templates/object-template/object-template.tsx
@@ -30,15 +30,19 @@ const WrapObjectItem = <T extends object>({
   FieldWrapper,
   data,
 }: WrapObjectItemProps<T>) => {
-  const config = useFieldConfiguration(fieldId);
+  const {renderer: Renderer, ...config} = useFieldConfiguration(fieldId);
+  const value = _.get(data, config.keyPath);
   return (
     <FieldWrapper
       data={data}
       fieldId={fieldId}
       field={config.keyPath as IdType<T>}
-      value={_.get(data, config.keyPath)}
+      value={value}
+      renderer={Renderer}
       {...config}
-    />
+    >
+      <Renderer value={value} />
+    </FieldWrapper>
   );
 };
 

--- a/src/templates/object-template/object-template.tsx
+++ b/src/templates/object-template/object-template.tsx
@@ -35,7 +35,7 @@ const WrapObjectItem = <T extends object>({
   const value = _.get(data, config.keyPath);
   return (
     <FieldWrapper
-      data={data}
+      item={data}
       fieldId={fieldId}
       field={config.keyPath as IdType<T>}
       value={value}

--- a/src/templates/object-template/object-template.tsx
+++ b/src/templates/object-template/object-template.tsx
@@ -7,7 +7,7 @@ import {
   FieldConfigurationProvider,
 } from '../configuration';
 import {FieldWrapperType, TemplateWrapperType} from '../support';
-import {DefaultWrapper, RenderItem} from '../common';
+import {DefaultWrapper, RenderItem, RenderTemplate} from '../common';
 
 export interface ObjectTemplateProps<T extends object> {
   data: Maybe<T>;
@@ -32,20 +32,15 @@ export const UnboundObjectTemplate = <T extends object>({
     return null;
   }
 
-  const children = (
-    <RenderItem
-      item={data}
-      ItemWrapper={ItemWrapper}
-      FieldWrapper={FieldWrapper}
-    />
+  return (
+    <RenderTemplate data={data} TemplateWrapper={TemplateWrapper}>
+      <RenderItem
+        item={data}
+        ItemWrapper={ItemWrapper}
+        FieldWrapper={FieldWrapper}
+      />
+    </RenderTemplate>
   );
-
-  if (typeof TemplateWrapper === 'string') {
-    const Tag = TemplateWrapper as keyof JSX.IntrinsicElements;
-    return <Tag>{children}</Tag>;
-  }
-
-  return <TemplateWrapper data={data}>{children}</TemplateWrapper>;
 };
 
 export const ObjectTemplate = <T extends object>({

--- a/src/templates/object-template/object-template.tsx
+++ b/src/templates/object-template/object-template.tsx
@@ -5,10 +5,9 @@ import {
   ConfigureFunction,
   Configurer,
   FieldConfigurationProvider,
-  useConfiguredFieldIds,
 } from '../configuration';
 import {FieldWrapperType, TemplateWrapperType} from '../support';
-import {DefaultWrapper, RenderField} from '../common';
+import {DefaultWrapper, RenderItem} from '../common';
 
 export interface ObjectTemplateProps<T extends object> {
   data: Maybe<T>;
@@ -27,21 +26,19 @@ export const UnboundObjectTemplate = <T extends object>({
   data,
   TemplateWrapper = DefaultWrapper,
   ItemWrapper = DefaultWrapper,
-  FieldWrapper,
+  FieldWrapper = DefaultWrapper,
 }: UnboundObjectTemplateProps<T>) => {
-  const fieldIds = useConfiguredFieldIds<T>();
   if (!data) {
     return null;
   }
 
-  const children = fieldIds.map((fieldId) => (
-    <RenderField
-      key={fieldId}
+  const children = (
+    <RenderItem
       item={data}
-      fieldId={fieldId}
+      ItemWrapper={ItemWrapper}
       FieldWrapper={FieldWrapper}
     />
-  ));
+  );
 
   if (typeof TemplateWrapper === 'string') {
     const Tag = TemplateWrapper as keyof JSX.IntrinsicElements;

--- a/src/templates/object-template/object-template.tsx
+++ b/src/templates/object-template/object-template.tsx
@@ -9,21 +9,18 @@ import {
   useConfiguredFieldIds,
   useFieldConfiguration,
 } from '../configuration';
-import {
-  FieldWrapper as FieldWrapperType,
-  Wrapper as WrapperType,
-} from '../support';
+import {FieldWrapperType, TemplateWrapperType} from '../support';
 
 export interface ObjectTemplateProps<T extends object> {
   data: Maybe<T>;
   configure: ConfigureFunction<T>;
-  Wrapper: WrapperType<Maybe<T>>;
+  TemplateWrapper: TemplateWrapperType<Maybe<T>>;
   FieldWrapper: FieldWrapperType<T>;
 }
 
 type WrapObjectItemProps<T extends object> = Omit<
   UnboundObjectTemplateProps<T>,
-  'Wrapper'
+  'TemplateWrapper'
 > & {
   data: T;
   fieldId: string;
@@ -52,7 +49,7 @@ export type UnboundObjectTemplateProps<T extends object> = Omit<
 
 export const UnboundObjectTemplate = <T extends object>({
   data,
-  Wrapper,
+  TemplateWrapper,
   FieldWrapper,
 }: UnboundObjectTemplateProps<T>) => {
   const fieldIds = useConfiguredFieldIds<T>();
@@ -69,12 +66,12 @@ export const UnboundObjectTemplate = <T extends object>({
     />
   ));
 
-  if (typeof Wrapper === 'string') {
-    const Tag = Wrapper as keyof JSX.IntrinsicElements;
+  if (typeof TemplateWrapper === 'string') {
+    const Tag = TemplateWrapper as keyof JSX.IntrinsicElements;
     return <Tag>{children}</Tag>;
   }
 
-  return <Wrapper data={data}>{children}</Wrapper>;
+  return <TemplateWrapper data={data}>{children}</TemplateWrapper>;
 };
 
 export const ObjectTemplate = <T extends object>({

--- a/src/templates/object-template/object-template.tsx
+++ b/src/templates/object-template/object-template.tsx
@@ -15,30 +15,29 @@ export interface ObjectTemplateProps<T extends object> {
   TemplateWrapper?: TemplateWrapperType<Maybe<T>>;
   ItemWrapper?: ItemWrapperType<T>;
   FieldWrapper?: FieldWrapperType<T>;
+  noDataSlot?: React.ReactElement;
 }
 
 export const ObjectTemplate = <T extends object>({
   configure: Configure,
   data,
+  noDataSlot,
   TemplateWrapper = DefaultWrapper,
   ItemWrapper = DefaultWrapper,
   FieldWrapper = DefaultWrapper,
-}: ObjectTemplateProps<T>) => {
-  if (!data) {
-    return null;
-  }
-  return (
-    <>
-      <FieldConfigurationProvider>
-        {Configure && <Configure FieldConfigurer={Configurer} />}
-        <RenderTemplate data={data} TemplateWrapper={TemplateWrapper}>
-          <RenderItem
-            item={data}
-            ItemWrapper={ItemWrapper}
-            FieldWrapper={FieldWrapper}
-          />
-        </RenderTemplate>
-      </FieldConfigurationProvider>
-    </>
-  );
-};
+}: ObjectTemplateProps<T>) => (
+  <FieldConfigurationProvider>
+    {Configure && <Configure FieldConfigurer={Configurer} />}
+    {data ? (
+      <RenderTemplate data={data} TemplateWrapper={TemplateWrapper}>
+        <RenderItem
+          item={data}
+          ItemWrapper={ItemWrapper}
+          FieldWrapper={FieldWrapper}
+        />
+      </RenderTemplate>
+    ) : (
+      noDataSlot
+    )}
+  </FieldConfigurationProvider>
+);

--- a/src/templates/object-template/object-template.tsx
+++ b/src/templates/object-template/object-template.tsx
@@ -11,7 +11,7 @@ import {DefaultWrapper, RenderItem, RenderTemplate} from '../common';
 
 export interface ObjectTemplateProps<T extends object> {
   data: Maybe<T>;
-  configure: ConfigureFunction<T>;
+  configure?: ConfigureFunction<T>;
   TemplateWrapper?: TemplateWrapperType<Maybe<T>>;
   ItemWrapper?: ItemWrapperType<T>;
   FieldWrapper?: FieldWrapperType<T>;
@@ -30,7 +30,7 @@ export const ObjectTemplate = <T extends object>({
   return (
     <>
       <FieldConfigurationProvider>
-        <Configure FieldConfigurer={Configurer} />
+        {Configure && <Configure FieldConfigurer={Configurer} />}
         <RenderTemplate data={data} TemplateWrapper={TemplateWrapper}>
           <RenderItem
             item={data}

--- a/src/templates/object-template/object-template.tsx
+++ b/src/templates/object-template/object-template.tsx
@@ -17,40 +17,28 @@ export interface ObjectTemplateProps<T extends object> {
   FieldWrapper?: FieldWrapperType<T>;
 }
 
-export type UnboundObjectTemplateProps<T extends object> = Omit<
-  ObjectTemplateProps<T>,
-  'configure'
->;
-
-export const UnboundObjectTemplate = <T extends object>({
+export const ObjectTemplate = <T extends object>({
+  configure: Configure,
   data,
   TemplateWrapper = DefaultWrapper,
   ItemWrapper = DefaultWrapper,
   FieldWrapper = DefaultWrapper,
-}: UnboundObjectTemplateProps<T>) => {
+}: ObjectTemplateProps<T>) => {
   if (!data) {
     return null;
   }
-
   return (
-    <RenderTemplate data={data} TemplateWrapper={TemplateWrapper}>
-      <RenderItem
-        item={data}
-        ItemWrapper={ItemWrapper}
-        FieldWrapper={FieldWrapper}
-      />
-    </RenderTemplate>
+    <>
+      <FieldConfigurationProvider>
+        <Configure FieldConfigurer={Configurer} />
+        <RenderTemplate data={data} TemplateWrapper={TemplateWrapper}>
+          <RenderItem
+            item={data}
+            ItemWrapper={ItemWrapper}
+            FieldWrapper={FieldWrapper}
+          />
+        </RenderTemplate>
+      </FieldConfigurationProvider>
+    </>
   );
 };
-
-export const ObjectTemplate = <T extends object>({
-  configure: Configure,
-  ...rest
-}: ObjectTemplateProps<T>) => (
-  <>
-    <FieldConfigurationProvider>
-      <Configure FieldConfigurer={Configurer} />
-      <UnboundObjectTemplate {...rest} />
-    </FieldConfigurationProvider>
-  </>
-);

--- a/src/templates/object-template/object-template.tsx
+++ b/src/templates/object-template/object-template.tsx
@@ -10,12 +10,13 @@ import {
   useFieldConfiguration,
 } from '../configuration';
 import {FieldWrapperType, TemplateWrapperType} from '../support';
+import {DefaultWrapper} from '../common';
 
 export interface ObjectTemplateProps<T extends object> {
   data: Maybe<T>;
   configure: ConfigureFunction<T>;
-  TemplateWrapper: TemplateWrapperType<Maybe<T>>;
-  FieldWrapper: FieldWrapperType<T>;
+  TemplateWrapper?: TemplateWrapperType<Maybe<T>>;
+  FieldWrapper?: FieldWrapperType<T>;
 }
 
 type WrapObjectItemProps<T extends object> = Omit<
@@ -27,7 +28,7 @@ type WrapObjectItemProps<T extends object> = Omit<
 };
 const WrapObjectItem = <T extends object>({
   fieldId,
-  FieldWrapper,
+  FieldWrapper = DefaultWrapper,
   data,
 }: WrapObjectItemProps<T>) => {
   const {renderer: Renderer, ...config} = useFieldConfiguration(fieldId);
@@ -53,7 +54,7 @@ export type UnboundObjectTemplateProps<T extends object> = Omit<
 
 export const UnboundObjectTemplate = <T extends object>({
   data,
-  TemplateWrapper,
+  TemplateWrapper = DefaultWrapper,
   FieldWrapper,
 }: UnboundObjectTemplateProps<T>) => {
   const fieldIds = useConfiguredFieldIds<T>();

--- a/src/templates/object-template/object-template.tsx
+++ b/src/templates/object-template/object-template.tsx
@@ -1,51 +1,22 @@
-import _ from 'lodash';
 import React from 'react';
 
-import {IdType, Maybe} from '../..';
+import {ItemWrapperType, Maybe} from '../..';
 import {
   ConfigureFunction,
   Configurer,
   FieldConfigurationProvider,
   useConfiguredFieldIds,
-  useFieldConfiguration,
 } from '../configuration';
 import {FieldWrapperType, TemplateWrapperType} from '../support';
-import {DefaultWrapper} from '../common';
+import {DefaultWrapper, RenderField} from '../common';
 
 export interface ObjectTemplateProps<T extends object> {
   data: Maybe<T>;
   configure: ConfigureFunction<T>;
   TemplateWrapper?: TemplateWrapperType<Maybe<T>>;
+  ItemWrapper?: ItemWrapperType<T>;
   FieldWrapper?: FieldWrapperType<T>;
 }
-
-type WrapObjectItemProps<T extends object> = Omit<
-  UnboundObjectTemplateProps<T>,
-  'TemplateWrapper'
-> & {
-  data: T;
-  fieldId: string;
-};
-const WrapObjectItem = <T extends object>({
-  fieldId,
-  FieldWrapper = DefaultWrapper,
-  data,
-}: WrapObjectItemProps<T>) => {
-  const {renderer: Renderer, ...config} = useFieldConfiguration(fieldId);
-  const value = _.get(data, config.keyPath);
-  return (
-    <FieldWrapper
-      item={data}
-      fieldId={fieldId}
-      field={config.keyPath as IdType<T>}
-      value={value}
-      renderer={Renderer}
-      {...config}
-    >
-      <Renderer value={value} />
-    </FieldWrapper>
-  );
-};
 
 export type UnboundObjectTemplateProps<T extends object> = Omit<
   ObjectTemplateProps<T>,
@@ -55,6 +26,7 @@ export type UnboundObjectTemplateProps<T extends object> = Omit<
 export const UnboundObjectTemplate = <T extends object>({
   data,
   TemplateWrapper = DefaultWrapper,
+  ItemWrapper = DefaultWrapper,
   FieldWrapper,
 }: UnboundObjectTemplateProps<T>) => {
   const fieldIds = useConfiguredFieldIds<T>();
@@ -63,9 +35,9 @@ export const UnboundObjectTemplate = <T extends object>({
   }
 
   const children = fieldIds.map((fieldId) => (
-    <WrapObjectItem
+    <RenderField
       key={fieldId}
-      data={data}
+      item={data}
       fieldId={fieldId}
       FieldWrapper={FieldWrapper}
     />

--- a/src/templates/object-template/support.tsx
+++ b/src/templates/object-template/support.tsx
@@ -3,17 +3,14 @@ import React from 'react';
 import {Description, DescriptionList, IdType, Maybe} from '../..';
 import {FieldWrapperProps} from '../support';
 
-export const ItemWrapper = <T extends object, K extends IdType<T>>({
+export const FieldWrapper = <T extends object, K extends IdType<T>>({
   label,
-  value,
-  renderer: Renderer,
+  children,
 }: FieldWrapperProps<T, K>) => (
-  <Description term={label}>
-    <Renderer value={value} />
-  </Description>
+  <Description term={label}>{children}</Description>
 );
 
-export const Wrapper = <T extends object>({
+export const TemplateWrapper = <T extends object>({
   children,
 }: React.PropsWithChildren<{data: Maybe<T>}>) => (
   <DescriptionList>{children}</DescriptionList>

--- a/src/templates/support.tsx
+++ b/src/templates/support.tsx
@@ -5,7 +5,9 @@ import {IdType} from '..';
 import {FieldConfiguration} from './configuration';
 
 export type TemplateWrapperProps<T> = React.PropsWithChildren<{data: T}>;
-export type TemplateWrapperType<T> = React.ElementType<TemplateWrapperProps<T>>;
+export type TemplateWrapperType<T> =
+  | keyof JSX.IntrinsicElements
+  | React.ElementType<TemplateWrapperProps<T>>;
 
 export type ItemWrapperProps<T extends object> = React.PropsWithChildren<{
   item: T;

--- a/src/templates/support.tsx
+++ b/src/templates/support.tsx
@@ -14,15 +14,22 @@ export type ItemWrapperType<T extends object> = React.ElementType<
   ItemWrapperProps<T>
 >;
 
-export interface FieldWrapperProps<T extends object, K extends IdType<T>>
-  extends FieldConfiguration {
-  fieldId: string;
-  field: K;
-  value: T[K];
-  data: T;
-}
-export interface FieldWrapperType<T extends object> {
-  <T2 extends T, K2 extends IdType<T2>>(
-    props: FieldWrapperProps<T2, K2>
-  ): React.ReactElement | null;
-}
+export type FieldWrapperProps<
+  T extends object,
+  K extends IdType<T>
+> = React.PropsWithChildren<
+  FieldConfiguration & {
+    fieldId: string;
+    field: K;
+    value: T[K];
+    data: T;
+  }
+>;
+export type FieldWrapperType<T extends object> = <
+  T2 extends T,
+  K2 extends IdType<T2>
+>(
+  props: FieldWrapperProps<T2, K2>
+) => React.ReactElement | null;
+
+export const DefaultWrapper: React.FC = ({children}) => <>{children}</>;

--- a/src/templates/support.tsx
+++ b/src/templates/support.tsx
@@ -20,7 +20,7 @@ export type FieldWrapperProps<
   T extends object,
   K extends IdType<T>
 > = React.PropsWithChildren<
-  FieldConfiguration & {
+  Omit<FieldConfiguration, 'wrapper'> & {
     fieldId: string;
     field: K;
     value: T[K];

--- a/src/templates/support.tsx
+++ b/src/templates/support.tsx
@@ -1,24 +1,16 @@
+import React from 'react';
+
 import {IdType} from '..';
 
 import {FieldConfiguration} from './configuration';
 
-export interface WrapperOwnProps<T> {
+export type TemplateWrapperProps<T> = React.PropsWithChildren<{data: T}>;
+export type TemplateWrapperType<T> = React.ElementType<TemplateWrapperProps<T>>;
+
+export type ItemWrapperProps<T extends object> = React.PropsWithChildren<{
   data: T;
-}
-
-export type WrapperProps<T> = React.PropsWithChildren<WrapperOwnProps<T>>;
-
-export type Wrapper<T> = React.ElementType<WrapperProps<T>>;
-
-export interface ItemWrapperOwnProps<T extends object> {
-  data: T;
-}
-
-export type ItemWrapperProps<T extends object> = React.PropsWithChildren<
-  ItemWrapperOwnProps<T>
->;
-
-export type ItemWrapper<T extends object> = React.ElementType<
+}>;
+export type ItemWrapperType<T extends object> = React.ElementType<
   ItemWrapperProps<T>
 >;
 
@@ -29,8 +21,7 @@ export interface FieldWrapperProps<T extends object, K extends IdType<T>>
   value: T[K];
   data: T;
 }
-
-export interface FieldWrapper<T extends object> {
+export interface FieldWrapperType<T extends object> {
   <T2 extends T, K2 extends IdType<T2>>(
     props: FieldWrapperProps<T2, K2>
   ): React.ReactElement | null;

--- a/src/templates/support.tsx
+++ b/src/templates/support.tsx
@@ -8,7 +8,7 @@ export type TemplateWrapperProps<T> = React.PropsWithChildren<{data: T}>;
 export type TemplateWrapperType<T> = React.ElementType<TemplateWrapperProps<T>>;
 
 export type ItemWrapperProps<T extends object> = React.PropsWithChildren<{
-  data: T;
+  item: T;
 }>;
 export type ItemWrapperType<T extends object> = React.ElementType<
   ItemWrapperProps<T>
@@ -22,7 +22,7 @@ export type FieldWrapperProps<
     fieldId: string;
     field: K;
     value: T[K];
-    data: T;
+    item: T;
   }
 >;
 export type FieldWrapperType<T extends object> =

--- a/src/templates/support.tsx
+++ b/src/templates/support.tsx
@@ -10,9 +10,9 @@ export type TemplateWrapperType<T> = React.ElementType<TemplateWrapperProps<T>>;
 export type ItemWrapperProps<T extends object> = React.PropsWithChildren<{
   item: T;
 }>;
-export type ItemWrapperType<T extends object> = React.ElementType<
-  ItemWrapperProps<T>
->;
+export type ItemWrapperType<T extends object> =
+  | keyof JSX.IntrinsicElements
+  | React.ElementType<ItemWrapperProps<T>>;
 
 export type FieldWrapperProps<
   T extends object,

--- a/src/templates/support.tsx
+++ b/src/templates/support.tsx
@@ -25,11 +25,8 @@ export type FieldWrapperProps<
     data: T;
   }
 >;
-export type FieldWrapperType<T extends object> = <
-  T2 extends T,
-  K2 extends IdType<T2>
->(
-  props: FieldWrapperProps<T2, K2>
-) => React.ReactElement | null;
-
-export const DefaultWrapper: React.FC = ({children}) => <>{children}</>;
+export type FieldWrapperType<T extends object> =
+  | keyof JSX.IntrinsicElements
+  | (<T2 extends T, K2 extends IdType<T2>>(
+      props: FieldWrapperProps<T2, K2>
+    ) => React.ReactElement | null);

--- a/src/templates/templates.stories.mdx
+++ b/src/templates/templates.stories.mdx
@@ -143,7 +143,7 @@ and then, your code is simply
 ```tsx
 <TemplatedDescriptionList
   data={data?.node?.myConnection?.edges?.[0]}
-  configure={({FieldcConfigurer}) => (
+  configure={({FieldConfigurer}) => (
     <>
       <FieldConfigurer name="foo" />
       <FieldConfigurer name="bar" />
@@ -156,11 +156,18 @@ and then, your code is simply
 These are fairly contrived examples, and there's a lot missing from the
 `TemplatedDescriptionList` (e.g., we should expect renderProps for transforming
 both the key and the value and it would probably better to wrap
-ConditionalDescription instead of Description). Further, the FieldConfigurer
+ConditionalDescription instead of Description).
 
-<!-- Notes -->
+## Interfaces
 
-interface FieldConfigurer { /\*\*
+Each Template accepts three Wrappers. In general, Wrappers should take care to
+render their `children`, as that's where the next lower Wrapper will be
+rendered, however in custom cases, it may make sense to discard the lower-level
+Wrappers and do the whole thing at one shot.
 
-- Renders the whole k/v pair. We might use this to replace the \*/ renderPair:
-  void; renderKey: void; renderValue: void }
+- `TemplateWrapper` - Wraps the entire dataset.
+- `ItemWrapper` - Wraps a single item in the dataset. If the dataset is an
+   array, this wraps an item in the array. If the dataset is an object, this
+   wraps the entire object.
+- `FieldWrapper` - Wraps a single field.
+


### PR DESCRIPTION
This PR will contains lots of breaking changes are templates with the hope that they become much easier to use

## Build Fixes

- [x] fix crr for lint

## Breaking Changes

- [X] Renderer
  - [X] Default is AnyRenderer
  - [X] always passes a value prop
- [X] Wrapper
  - [X] Default is noop fragment around children prop
  - [X] always passes a children prop

## Features

- [X] Make all Wrappers optional
- [x] Remove `Unbound*` components
- [ ] `FieldWrapper` gets `item` and `data`
  - [ ] Nested FieldConfigurers should get whole item and not just the subobject their value comes from
- [ ] `ItemWrapper` gets `item` and `data`
  - [ ] Nested FieldConfigurers should get whole item and not just the subobject their value comes from
- [x] make configure optional (not strictly needed for many combinations of wrappers
- [ ] punted ~[Export all TemplateSpecialization subcomponents so they can be used in overrides](https://github.com/code-like-a-carpenter/components/issues/188)~
- [x] FieldConfigurer should accept wrapper as well as renderer
- [x] Add a NoData slot
- [ ] punted ~[Add LabelWrapper/HeaderWrapper (/FooterWrapper?)](https://github.com/code-like-a-carpenter/components/issues/189)~

## Stretch

- [ ] quiet storyshots log errors
- [ ] Make nested object fields available via typescript template string types and lodash path magic
- [ ] Pager/usePagination need to accept an optional prefix so multiple pagers may appear on the same page
- [ ] ConnectionTemplate should pass `connection` to wrappers, not just nodes array
- [ ] ConnectionTemplate should pass `edge` to wrappers, not just node array