### PR TITLE
cleanup

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,9 +2,15 @@ import './styles.scss'
 
 import {faker} from '@faker-js/faker';
 
+const seed = 1701;
+// set the seed to ensure data generated outside of stories is consistent
+faker.seed(seed);
+
 export const decorators = [
   (Story) => {
-    faker.seed(1701);
+    // set the seed again to ensure data generated within each story starts from
+    // the same seed
+    faker.seed(seed);
     return <Story />;
   },
 ];

--- a/src/renderers/any-renderer/any-renderer.tsx
+++ b/src/renderers/any-renderer/any-renderer.tsx
@@ -1,7 +1,7 @@
 import {DateTime} from 'luxon';
 import {createContext, isValidElement} from 'react';
 
-import {useContextWithDefaults} from '../../support';
+import {useContextWithPropOverrides} from '../../support';
 import {BooleanRenderer, BooleanRendererContextType} from '../boolean-renderer';
 import {DateRenderer, DateRendererContextProps} from '../date-renderer';
 import {NullRenderer, NullRendererContextType} from '../null-renderer';
@@ -24,7 +24,7 @@ export const AnyRenderer = ({value, ...rest}: AnyRendererProps) => {
     boolean,
     date,
     null: nullDefaults,
-  } = useContextWithDefaults(AnyRendererContext, rest);
+  } = useContextWithPropOverrides(AnyRendererContext, rest);
 
   if (
     typeof value === 'object' ||

--- a/src/renderers/boolean-renderer/boolean-renderer.tsx
+++ b/src/renderers/boolean-renderer/boolean-renderer.tsx
@@ -1,6 +1,6 @@
 import {createContext} from 'react';
 
-import {useContextWithDefaults} from '../../support';
+import {useContextWithPropOverrides} from '../../support';
 import {RendererDefault, RendererProps} from '../types';
 
 export interface BooleanRendererContextType {
@@ -21,7 +21,7 @@ export type BooleanRendererProps = RendererProps<
 >;
 
 export const BooleanRenderer = ({value, ...rest}: BooleanRendererProps) => {
-  const {no, yes} = useContextWithDefaults(BooleanRendererContext, rest);
+  const {no, yes} = useContextWithPropOverrides(BooleanRendererContext, rest);
 
   return <span className="magic-boolean">{value ? yes : no}</span>;
 };

--- a/src/renderers/date-renderer/date-renderer.tsx
+++ b/src/renderers/date-renderer/date-renderer.tsx
@@ -3,7 +3,7 @@ import assert from 'assert';
 import {DateTime, Duration} from 'luxon';
 import {createContext} from 'react';
 
-import {useContextWithDefaults} from '../../support';
+import {useContextWithPropOverrides} from '../../support';
 import {NullRenderer} from '../null-renderer';
 import {RendererProps} from '../types';
 
@@ -37,7 +37,7 @@ export type DateRendererProps = RendererProps<
 
 export const DateRenderer = ({value, ...rest}: DateRendererProps) => {
   const {format, negativeIsNull, range, reference, relative} =
-    useContextWithDefaults(DateRendererContext, rest);
+    useContextWithPropOverrides(DateRendererContext, rest);
 
   const dt = parseDate(value);
 

--- a/src/renderers/null-renderer/null-renderer.tsx
+++ b/src/renderers/null-renderer/null-renderer.tsx
@@ -1,6 +1,6 @@
 import {createContext} from 'react';
 
-import {useContextWithDefaults} from '../../support';
+import {useContextWithPropOverrides} from '../../support';
 import {RendererDefault, RendererProps} from '../types';
 
 export interface NullRendererContextType {
@@ -14,6 +14,9 @@ export const NullRendererContext = createContext<NullRendererContextType>({
 export type NullRendererProps = RendererProps<null, NullRendererContextType>;
 
 export const NullRenderer = (props: NullRendererProps) => {
-  const {null: content} = useContextWithDefaults(NullRendererContext, props);
+  const {null: content} = useContextWithPropOverrides(
+    NullRendererContext,
+    props
+  );
   return <>{content}</>;
 };

--- a/src/stringify/fancy-stringify.stories.tsx
+++ b/src/stringify/fancy-stringify.stories.tsx
@@ -1,9 +1,9 @@
 import {makeComplexPeople, makeSimplePerson} from '../mocks';
 
-import {FancyStringify as FancyStringifyComponent} from './fancy-stringify';
+import {FancyStringify} from './fancy-stringify';
 
 export default {
-  component: FancyStringifyComponent,
+  component: FancyStringify,
   title: 'Components/FancyStringify',
 };
 
@@ -14,6 +14,8 @@ const data = {
   },
 };
 
-export const FancyStringify = () => (
-  <FancyStringifyComponent>{data}</FancyStringifyComponent>
+export const DefaultDepth = () => <FancyStringify>{data}</FancyStringify>;
+
+export const ControlledDepth = () => (
+  <FancyStringify depth={3}>{data}</FancyStringify>
 );

--- a/src/stringify/fancy-stringify.tsx
+++ b/src/stringify/fancy-stringify.tsx
@@ -18,7 +18,7 @@ export const FancyStringify = <T extends unknown>({
 
   return (
     <Wrapper>
-      {Array.isArray(children) && `${indent}[`}{' '}
+      {Array.isArray(children) && `${indent}[`}
       {children &&
         Object.entries(children).map(([key, value], index, arr) => {
           if (value instanceof Date || typeof value !== 'object') {

--- a/src/stringify/stringify.stories.tsx
+++ b/src/stringify/stringify.stories.tsx
@@ -1,9 +1,9 @@
 import {makeComplexPeople, makeSimplePerson} from '../mocks';
 
-import {Stringify as StringifyComponent} from './stringify';
+import {Stringify} from './stringify';
 
 export default {
-  component: StringifyComponent,
+  component: Stringify,
   title: 'Components/Stringify',
 };
 
@@ -14,4 +14,6 @@ const data = {
   },
 };
 
-export const Stringify = () => <StringifyComponent>{data}</StringifyComponent>;
+export const DefaultDepth = () => <Stringify>{data}</Stringify>;
+
+export const ControlledDepth = () => <Stringify depth={3}>{data}</Stringify>;

--- a/src/stringify/stringify.tsx
+++ b/src/stringify/stringify.tsx
@@ -1,4 +1,4 @@
-import {HTMLProps} from 'react';
+import {HTMLProps, useMemo} from 'react';
 
 export interface StringifyProps<T extends unknown>
   extends Omit<HTMLProps<HTMLPreElement>, 'children'> {
@@ -11,8 +11,42 @@ export interface StringifyProps<T extends unknown>
  */
 export const Stringify = <T extends unknown>({
   children,
-  depth = 2,
+  depth: maxDepth = Infinity,
   ...rest
-}: StringifyProps<T>) => (
-  <pre {...rest}>{JSON.stringify(children, null, depth)}</pre>
-);
+}: StringifyProps<T>) => {
+  const replacer = useMemo(() => {
+    if (!Number.isFinite(maxDepth)) {
+      return undefined;
+    }
+
+    let currentDepth = 0;
+    let currentParent = children;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return function (this: any, key: string, value: any): any {
+      // eslint-disable-next-line no-invalid-this
+      if (this !== currentParent) {
+        currentDepth++;
+        // eslint-disable-next-line @typescript-eslint/no-this-alias,no-invalid-this
+        currentParent = this;
+      }
+
+      if (currentDepth <= maxDepth) {
+        return value;
+      }
+
+      if (typeof value === 'object') {
+        if (Array.isArray(value)) {
+          return `Array(${value.length})`;
+        }
+
+        if (value !== null) {
+          return `Object(${Object.keys(value).length})`;
+        }
+      }
+
+      return value;
+    };
+  }, [children, maxDepth]);
+
+  return <pre {...rest}>{JSON.stringify(children, replacer, 2)}</pre>;
+};

--- a/src/stringify/stringify.tsx
+++ b/src/stringify/stringify.tsx
@@ -3,6 +3,7 @@ import {HTMLProps} from 'react';
 export interface StringifyProps<T extends unknown>
   extends Omit<HTMLProps<HTMLPreElement>, 'children'> {
   children: T;
+  depth?: number;
 }
 
 /**
@@ -10,7 +11,8 @@ export interface StringifyProps<T extends unknown>
  */
 export const Stringify = <T extends unknown>({
   children,
+  depth = 2,
   ...rest
 }: StringifyProps<T>) => (
-  <pre {...rest}>{JSON.stringify(children, null, 2)}</pre>
+  <pre {...rest}>{JSON.stringify(children, null, depth)}</pre>
 );

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,25 @@
+:root {
+  --heading-anchor-icon: '#';
+}
+
+.heading__anchor {
+  padding: 0 .175rem;
+  font-weight: 400;
+  color: rgba(var(--bs-link-color), 0.5);
+  text-decoration: none;
+  opacity: 0;
+  transition: color 0.15s ease-in-out,opacity 0.15s ease-in-out;
+}
+
+.heading__anchor::after {
+  content: var(--heading-anchor-icon);
+}
+
+.heading__anchor:focus,
+.heading__anchor:hover,
+.heading:hover .heading__anchor,
+.heading:target .heading__anchor {
+  color: var(--bs-link-color);
+  text-decoration: none;
+  opacity: 1;
+}

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,25 +1,13 @@
-:root {
-  --heading-anchor-icon: '#';
-}
-
-.heading__anchor {
-  padding: 0 .175rem;
-  font-weight: 400;
-  color: rgba(var(--bs-link-color), 0.5);
-  text-decoration: none;
-  opacity: 0;
-  transition: color 0.15s ease-in-out,opacity 0.15s ease-in-out;
-}
-
-.heading__anchor::after {
-  content: var(--heading-anchor-icon);
-}
-
-.heading__anchor:focus,
-.heading__anchor:hover,
-.heading:hover .heading__anchor,
-.heading:target .heading__anchor {
-  color: var(--bs-link-color);
-  text-decoration: none;
-  opacity: 1;
-}
+// This is kind of a goofy hack. So far, there's no compelling reason to write
+// scss for this project, however, node-sass's default behavior is _not_ to
+// inline `*.css` files that are imported via `@import`. This makes a lot of
+// sense in the general case. If you're trying to `@import` a css file, it's
+// likely you want to do so at runtime and not compile time. Unfortunately, if
+// we're distributing styles via npm, we _do_ want them inlined.
+//
+// Of course, we could just stick to writing css in this file and be fine,
+// right? Well, no. A lot of the functions we want to use at runtime end up
+// being run at buildtime if they live in a sass file, so they need to 1. live
+// in a css file and 2. be imported via `@use` rather than `@import` so they get
+// inlined.
+@use 'style.css';

--- a/src/support.tsx
+++ b/src/support.tsx
@@ -11,14 +11,14 @@ import React, {
 } from 'react';
 
 /**
- * Like useContext, but allows for prop-defined defaults. Useful for e.g. theme
+ * Like useContext, but allows for prop-defined overrides. Useful for e.g. theme
  * providers where there may be a general theme for the app, but a single
  * component needs to render differently and adding a new Provider would be
  * overly verbose
  * @param context
  * @param propValues
  */
-export function useContextWithDefaults<T>(
+export function useContextWithPropOverrides<T>(
   context: Context<T>,
   propValues: Partial<T>
 ): T {


### PR DESCRIPTION
- fix: author css instead of sass
- ci: stabilize faker for stories using global mocks
- feat(stringify): add default depth
- fix(fancy-stringify): remove rogue whitespace
- feat(stringify): allow setting a max depth on stringify and other cleanup
- refactor: rename useContextWithDefaults to useContextWithPropOverrides
